### PR TITLE
Rename system identifier to PMD-Explorers-of-Fate

### DIFF
--- a/module/actor-sheet - copia.js
+++ b/module/actor-sheet - copia.js
@@ -3,8 +3,8 @@ export class MyActorSheet extends ActorSheet {
   /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["my-basic-system", "sheet", "actor"],
-      template: "systems/my-basic-system/templates/actor-sheet.hbs",
+      classes: ["PMD-Explorers-of-Fate", "sheet", "actor"],
+      template: "systems/PMD-Explorers-of-Fate/templates/actor-sheet.hbs",
       width: 500,
       height: 600,
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "stats" }],

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -3,8 +3,8 @@ export class MyActorSheet extends ActorSheet {
   /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["my-basic-system", "sheet", "actor"],
-      template: "systems/my-basic-system/templates/actor-sheet.hbs",
+      classes: ["PMD-Explorers-of-Fate", "sheet", "actor"],
+      template: "systems/PMD-Explorers-of-Fate/templates/actor-sheet.hbs",
       width: 500,
       height: 600,
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "stats" }],

--- a/module/init.js
+++ b/module/init.js
@@ -5,14 +5,14 @@ import { MoveItem } from "./item.js";
 import { MoveItemSheet } from "./item-sheet.js";
 
 Hooks.once("init", function () {
-  console.log("my-basic-system | Inicializando sistema básico");
+  console.log("PMD-Explorers-of-Fate | Inicializando sistema básico");
 
   // Registrar clases de documento
   CONFIG.Actor.documentClass = MyActor;
 
   // Registrar hoja por defecto para nuestro tipo
   Actors.unregisterSheet("core", ActorSheet);
-  Actors.registerSheet("my-basic-system", MyActorSheet, {
+  Actors.registerSheet("PMD-Explorers-of-Fate", MyActorSheet, {
     types: ["creature"],
     makeDefault: true,
     label: "Hoja de Criatura (Básica)"
@@ -20,7 +20,7 @@ Hooks.once("init", function () {
 
   // Item (movimientos)
   CONFIG.Item.documentClass = MoveItem;
-  Items.registerSheet("my-basic-system", MoveItemSheet, {
+  Items.registerSheet("PMD-Explorers-of-Fate", MoveItemSheet, {
     types: ["move"],
     makeDefault: true,
     label: "Movimiento"
@@ -28,5 +28,5 @@ Hooks.once("init", function () {
 });
 
 Hooks.once("ready", function () {
-  console.log("my-basic-system | Listo");
+  console.log("PMD-Explorers-of-Fate | Listo");
 });

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -2,8 +2,8 @@
 export class MoveItemSheet extends ItemSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["my-basic-system", "sheet", "item"],
-      template: "systems/my-basic-system/templates/item-move-sheet.hbs",
+      classes: ["PMD-Explorers-of-Fate", "sheet", "item"],
+      template: "systems/PMD-Explorers-of-Fate/templates/item-move-sheet.hbs",
       width: 480,
       height: 420,
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "details" }],

--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -1,5 +1,5 @@
 /* === Estilos base para la hoja de actor === */
-.my-basic-system.sheet.actor .my-sheet {
+.PMD-Explorers-of-Fate.sheet.actor .my-sheet {
   padding: 0.5rem;
 }
 
@@ -61,38 +61,38 @@
 }
 
 /* === Lista de movimientos en la ficha === */
-.my-basic-system.sheet.actor .item-list {
+.PMD-Explorers-of-Fate.sheet.actor .item-list {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.my-basic-system.sheet.actor .item-list .item-header {
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item-header {
   font-weight: 700;
   border-bottom: 1px solid var(--color-border, rgba(0,0,0,.2));
   padding: 4px 0;
 }
 
-.my-basic-system.sheet.actor .item-list .item {
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item {
   align-items: center;
   border-bottom: 1px dashed var(--color-border, rgba(0,0,0,.1));
   padding: 4px 0;
 }
 
-.my-basic-system.sheet.actor .item-list .item .item-name {
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-name {
   flex: 2;
 }
 
-.my-basic-system.sheet.actor .item-list .item .item-prop {
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-prop {
   flex: 0 0 70px;
   text-align: center;
 }
 
-.my-basic-system.sheet.actor .item-list .item .item-controls a {
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-controls a {
   margin-left: 6px;
 }
 
-.my-basic-system.sheet.actor .item-list .item-summary {
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item-summary {
   padding: 0 0 6px 0;
   color: var(--color-text-dark-5);
   font-style: italic;

--- a/system.json
+++ b/system.json
@@ -1,5 +1,5 @@
 {
-  "id": "my-basic-system",
+  "id": "PMD-Explorers-of-Fate",
   "title": "Pokemon Mistery Dungeon Explorer of Fate",
   "description": "Sistema de PMD Explorer of fate 1.6",
   "version": "0.1.0",


### PR DESCRIPTION
## Summary
- replace the old my-basic-system identifier with PMD-Explorers-of-Fate throughout the manifest, sheet registrations, and templates
- align stylesheet selectors and log messages with the new system name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc27f8a878832b93205f7405117e31