### PR TITLE
Add narrative actor attributes

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -22,6 +22,10 @@ export class MyActor extends Actor {
     sys.belly       = num(sys.belly, 100);
     sys.type1 = String(sys.type1 ?? "");
     sys.type2 = String(sys.type2 ?? "");
+    sys.pasiva = String(sys.pasiva ?? "");
+    sys.destino = String(sys.destino ?? "");
+    sys.leyenda = String(sys.leyenda ?? "");
+    sys.background = String(sys.background ?? "");
 
 
     // HP (opcionalmente clamp si lo deseas)

--- a/template.json
+++ b/template.json
@@ -13,6 +13,10 @@
         "stab": 0,
         "basicattack": 0,
         "belly": 0,
+        "pasiva": "",
+        "destino": "",
+        "leyenda": "",
+        "background": "",
         "skills": {
           "athletics": 15,
           "craft": 15,

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -11,6 +11,22 @@
           <input type="number" name="system.lvl" value="{{system.lvl}}" data-dtype="Number"/>
         </div>
         <div>
+          <label>Pasiva</label>
+          <input type="text" name="system.pasiva" value="{{system.pasiva}}" />
+        </div>
+        <div>
+          <label>Destino</label>
+          <input type="text" name="system.destino" value="{{system.destino}}" />
+        </div>
+        <div>
+          <label>Leyenda</label>
+          <input type="text" name="system.leyenda" value="{{system.leyenda}}" />
+        </div>
+        <div>
+          <label>Background</label>
+          <input type="text" name="system.background" value="{{system.background}}" />
+        </div>
+        <div>
           <label>Velocidad</label>
           <input type="number" name="system.speed" value="{{system.speed}}" data-dtype="Number"/>
         </div>


### PR DESCRIPTION
## Summary
- add narrative string attributes (Pasiva, Destino, Leyenda y Background) to the base actor template
- expose the new fields on the actor sheet header between the name and speed inputs
- sanitize the new string attributes when preparing actor data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc2b723a30832b88959657854c8c1e