### PR TITLE
Add experience tracking and LP stat

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -34,6 +34,14 @@ export class MyActor extends Actor {
     sys.hp.value = num(sys.hp.value, sys.hp.max);
     sys.hp.value = Math.clamp(sys.hp.value, 0, sys.hp.max);
 
+    const level = num(sys.lvl, 1);
+    sys.experience ??= { max: level * 100, value: 0 };
+    sys.experience.value = num(sys.experience.value, 0);
+    sys.experience.max = Math.max(0, level * 100);
+    sys.experience.value = Math.clamp(sys.experience.value, 0, sys.experience.max);
+
+    sys.lp = num(sys.lp, 0);
+
     // --- Habilidades: asegurar objeto y aplicar límites 15..95 ---
     const SK = [
       "athletics","craft","endurance","finesse","medicine",

--- a/template.json
+++ b/template.json
@@ -5,6 +5,7 @@
       "baseCreature": {
         "lvl": 1,
         "hp": { "max": 10, "value": 10 },
+        "experience": { "max": 100, "value": 0 },
         "attack": 0,
         "spAttack": 0,
         "defense": 0,
@@ -12,6 +13,7 @@
         "speed": 0,
         "stab": 0,
         "basicattack": 0,
+        "lp": 0,
         "belly": 0,
         "pasiva": "",
         "destino": "",

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -64,6 +64,15 @@
           <input type="number" name="system.hp.max" value="{{system.hp.max}}" data-dtype="Number"/>
         </div>
 
+        <div class="stat">
+          <label>EXP Actual</label>
+          <input type="number" name="system.experience.value" value="{{system.experience.value}}" data-dtype="Number"/>
+        </div>
+        <div class="stat">
+          <label>EXP Máxima</label>
+          <input type="number" name="system.experience.max" value="{{system.experience.max}}" data-dtype="Number" readonly/>
+        </div>
+
         <div class="stat restore-resources full-width">
           <button type="button" data-action="restore-actor">Restaurar HP y PP</button>
         </div>
@@ -93,6 +102,11 @@
         <div class="stat">
           <label>Basic Attack</label>
           <input type="number" name="system.basicattack" value="{{system.basicattack}}" data-dtype="Number"/>
+        </div>
+
+        <div class="stat">
+          <label>LP</label>
+          <input type="number" name="system.lp" value="{{system.lp}}" data-dtype="Number"/>
         </div>
 
         <div class="stat">


### PR DESCRIPTION
## Summary
- add a derived experience resource to actors with a maximum equal to level × 100
- expose current/max experience values and a new LP field on the actor sheet
- seed default experience and LP values in the actor template data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cca6bf3f40832babd9153a1b4e9778