### PR TITLE
Add inventory tab and item types

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -39,6 +39,34 @@ export class MyActorSheet extends ActorSheet {
       .filter(i => i.type === "move")
       .sort((a, b) => a.name.localeCompare(b.name));
 
+    const typeList = (type) => this.actor.items
+      .filter((i) => i.type === type)
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    data.inventorySections = [
+      {
+        type: "equipment",
+        label: "Equipamiento",
+        createLabel: "+ Nuevo equipamiento",
+        emptyHint: "Arrastra Items tipo <b>Equipamiento</b> o usa “+ Nuevo equipamiento”.",
+        items: typeList("equipment"),
+      },
+      {
+        type: "consumable",
+        label: "Consumibles",
+        createLabel: "+ Nuevo consumible",
+        emptyHint: "Arrastra Items tipo <b>Consumible</b> o usa “+ Nuevo consumible”.",
+        items: typeList("consumable"),
+      },
+      {
+        type: "gear",
+        label: "Otros objetos",
+        createLabel: "+ Nuevo objeto",
+        emptyHint: "Arrastra Items tipo <b>Objeto</b> o usa “+ Nuevo objeto”.",
+        items: typeList("gear"),
+      },
+    ];
+
     return data;
   }
 
@@ -83,6 +111,37 @@ export class MyActorSheet extends ActorSheet {
       const id = ev.currentTarget.closest("[data-item-id]")?.dataset.itemId;
       const item = this.actor.items.get(id);
       if (item) await this._useMove(item);
+    });
+
+    html.find("[data-action='create-item']").on("click", async (ev) => {
+      ev.preventDefault();
+      const type = ev.currentTarget.dataset.type;
+      if (!type) return;
+
+      const names = {
+        equipment: "Nuevo equipamiento",
+        consumable: "Nuevo consumible",
+        gear: "Nuevo objeto",
+      };
+
+      const created = await this.actor.createEmbeddedDocuments("Item", [{
+        name: names[type] ?? "Nuevo objeto",
+        type,
+        system: {},
+      }]);
+      created?.[0]?.sheet?.render(true);
+    });
+
+    html.find("[data-action='edit-item']").on("click", (ev) => {
+      ev.preventDefault();
+      const id = ev.currentTarget.closest("[data-item-id]")?.dataset.itemId;
+      this.actor.items.get(id)?.sheet?.render(true);
+    });
+
+    html.find("[data-action='delete-item']").on("click", async (ev) => {
+      ev.preventDefault();
+      const id = ev.currentTarget.closest("[data-item-id]")?.dataset.itemId;
+      if (id) await this.actor.deleteEmbeddedDocuments("Item", [id]);
     });
   }
 

--- a/module/init.js
+++ b/module/init.js
@@ -1,8 +1,8 @@
 // module/init.js
 import { MyActor } from "./actor.js";
 import { MyActorSheet } from "./actor-sheet.js";
-import { MoveItem } from "./item.js";
-import { MoveItemSheet } from "./item-sheet.js";
+import { PMDItem } from "./item.js";
+import { PMDItemSheet } from "./item-sheet.js";
 
 Hooks.once("init", function () {
   console.log("PMD-Explorers-of-Fate | Inicializando sistema básico");
@@ -18,12 +18,12 @@ Hooks.once("init", function () {
     label: "Hoja de Criatura (Básica)"
   });
 
-  // Item (movimientos)
-  CONFIG.Item.documentClass = MoveItem;
-  Items.registerSheet("PMD-Explorers-of-Fate", MoveItemSheet, {
-    types: ["move"],
+  // Items (movimientos y objetos)
+  CONFIG.Item.documentClass = PMDItem;
+  Items.registerSheet("PMD-Explorers-of-Fate", PMDItemSheet, {
+    types: ["move", "equipment", "consumable", "gear"],
     makeDefault: true,
-    label: "Movimiento"
+    label: "Objeto PMD"
   });
 });
 

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -1,9 +1,8 @@
 // module/item-sheet.js
-export class MoveItemSheet extends ItemSheet {
+export class PMDItemSheet extends ItemSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["PMD-Explorers-of-Fate", "sheet", "item"],
-      template: "systems/PMD-Explorers-of-Fate/templates/item-move-sheet.hbs",
       width: 480,
       height: 420,
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "details" }],
@@ -12,9 +11,22 @@ export class MoveItemSheet extends ItemSheet {
     });
   }
 
+  /** @override */
+  get template() {
+    if (this.item.type === "move") {
+      return "systems/PMD-Explorers-of-Fate/templates/item-move-sheet.hbs";
+    }
+    return "systems/PMD-Explorers-of-Fate/templates/item-object-sheet.hbs";
+  }
+
   getData(options) {
     const data = super.getData(options);
     data.system = this.item.system;
+    data.isMove = this.item.type === "move";
+    data.isEquipment = this.item.type === "equipment";
+    data.isConsumable = this.item.type === "consumable";
+    data.isGear = this.item.type === "gear";
+    data.itemType = this.item.type;
     return data;
   }
 }

--- a/module/item.js
+++ b/module/item.js
@@ -1,5 +1,5 @@
 // module/item.js
-export class MoveItem extends Item {
+export class PMDItem extends Item {
   /** @override */
   prepareDerivedData() {
     super.prepareDerivedData();
@@ -11,22 +11,53 @@ export class MoveItem extends Item {
       return Number.isFinite(n) ? n : d;
     };
 
-    sys.pp ??= { max: 10, value: 10 };
-    sys.pp.max   = Math.max(0, num(sys.pp.max, 10));
-    sys.pp.value = Math.clamp(num(sys.pp.value, sys.pp.max), 0, sys.pp.max);
+    switch (this.type) {
+      case "move": {
+        sys.pp ??= { max: 10, value: 10 };
+        sys.pp.max   = Math.max(0, num(sys.pp.max, 10));
+        sys.pp.value = Math.clamp(num(sys.pp.value, sys.pp.max), 0, sys.pp.max);
 
-    sys.accuracy = num(sys.accuracy, 75);
+        sys.accuracy = num(sys.accuracy, 75);
 
-    sys.baseDamage = Math.max(0, num(sys.baseDamage, 10));
+        sys.baseDamage = Math.max(0, num(sys.baseDamage, 10));
 
-    // Normaliza category
-    if (!["physical", "special", "status"].includes(sys.category)) {
-      sys.category = "physical";
+        // Normaliza category
+        if (!["physical", "special", "status"].includes(sys.category)) {
+          sys.category = "physical";
+        }
+
+        // Strings seguros
+        sys.range   = String(sys.range ?? "");
+        sys.element = String(sys.element ?? "");
+        sys.effect  = String(sys.effect ?? "");
+        break;
+      }
+
+      case "equipment":
+      case "consumable":
+      case "gear": {
+        const str = (v) => String(v ?? "");
+        const nonNeg = (v, d = 0) => Math.max(0, num(v, d));
+
+        sys.quantity = Math.max(0, Math.round(num(sys.quantity, 1)));
+        sys.weight   = nonNeg(sys.weight, 0);
+        sys.value    = nonNeg(sys.value, 0);
+
+        sys.description = str(sys.description);
+        sys.effect      = str(sys.effect);
+        sys.notes       = str(sys.notes);
+
+        if (this.type === "equipment") {
+          sys.slot = str(sys.slot);
+        }
+
+        if (this.type === "consumable") {
+          sys.uses ??= { max: 1, value: 1 };
+          sys.uses.max   = Math.max(0, Math.round(num(sys.uses.max, 1)));
+          sys.uses.value = Math.clamp(Math.round(num(sys.uses.value, sys.uses.max)), 0, sys.uses.max);
+        }
+        break;
+      }
     }
-
-    // Strings seguros
-    sys.range   = String(sys.range ?? "");
-    sys.element = String(sys.element ?? "");
-    sys.effect  = String(sys.effect ?? "");
   }
 }

--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -1,5 +1,7 @@
 /* === Estilos base para la hoja de actor === */
-.PMD-Explorers-of-Fate.sheet.actor .my-sheet {
+.PMD-Explorers-of-Fate.sheet.actor .my-sheet,
+.PMD-Explorers-of-Fate.sheet.item .my-move-sheet,
+.PMD-Explorers-of-Fate.sheet.item .my-item-sheet {
   padding: 0.5rem;
 }
 
@@ -7,13 +9,15 @@
   flex: 1;
 }
 
-.my-sheet .grid.two-col {
+.my-sheet .grid.two-col,
+.PMD-Explorers-of-Fate.sheet.item .grid.two-col {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px 12px;
 }
 
-.my-sheet .grid.two-col .stat.full-width {
+.my-sheet .grid.two-col .stat.full-width,
+.PMD-Explorers-of-Fate.sheet.item .grid.two-col .field.full-width {
   grid-column: 1 / -1;
 }
 
@@ -32,7 +36,8 @@
   gap: 6px 12px;
 }
 
-.my-sheet label {
+.my-sheet label,
+.PMD-Explorers-of-Fate.sheet.item label {
   font-weight: bold;
   font-size: 12px;
   color: var(--color-text-dark-6);
@@ -41,7 +46,11 @@
 .my-sheet input[type="number"],
 .my-sheet input[type="text"],
 .my-sheet textarea,
-.my-sheet select {
+.my-sheet select,
+.PMD-Explorers-of-Fate.sheet.item input[type="number"],
+.PMD-Explorers-of-Fate.sheet.item input[type="text"],
+.PMD-Explorers-of-Fate.sheet.item textarea,
+.PMD-Explorers-of-Fate.sheet.item select {
   width: 100%;
   box-sizing: border-box;
 }
@@ -99,6 +108,16 @@
 .PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-prop {
   flex: 0 0 70px;
   text-align: center;
+}
+
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-prop.detail,
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-prop.notes {
+  flex: 1;
+  text-align: left;
+}
+
+.PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-prop.notes {
+  padding-left: 6px;
 }
 
 .PMD-Explorers-of-Fate.sheet.actor .item-list .item .item-controls a {

--- a/template.json
+++ b/template.json
@@ -41,7 +41,17 @@
     }
   },
   "Item": {
-    "types": ["move"],
+    "types": ["move", "equipment", "consumable", "gear"],
+    "templates": {
+      "baseObject": {
+        "quantity": 1,
+        "weight": 0,
+        "value": 0,
+        "description": "",
+        "effect": "",
+        "notes": ""
+      }
+    },
     "move": {
       "range": "",
       "pp": { "max": 10, "value": 10 },
@@ -50,6 +60,17 @@
       "effect": "",
       "element": "",
       "baseDamage": 10
+    },
+    "equipment": {
+      "templates": ["baseObject"],
+      "slot": ""
+    },
+    "consumable": {
+      "templates": ["baseObject"],
+      "uses": { "max": 1, "value": 1 }
+    },
+    "gear": {
+      "templates": ["baseObject"]
     }
   }
 }

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -49,6 +49,7 @@
     <a class="item" data-tab="stats">Atributos</a>
     <a class="item" data-tab="skills">Habilidades</a>
     <a class="item" data-tab="moves">Movimientos</a>
+    <a class="item" data-tab="inventory">Objetos</a>
   </nav>
 
   <section class="sheet-body">
@@ -208,6 +209,94 @@
   {{else}}
     <p class="notes">Arrastra Items tipo <b>Movimiento</b> o usa “+ Nuevo movimiento”.</p>
   {{/if}}
+</div>
+
+<!-- ===== TAB: Objetos ===== -->
+<div class="tab" data-tab="inventory" data-group="primary">
+  {{#each inventorySections as |section|}}
+    <div class="inventory-section">
+      <div class="flexrow" style="justify-content: space-between; align-items: center; margin: 12px 0 6px;">
+        <h3 style="margin:0;">{{section.label}}</h3>
+        <button type="button" data-action="create-item" data-type="{{section.type}}">{{section.createLabel}}</button>
+      </div>
+
+      {{#if section.items.length}}
+        <ol class="item-list">
+          <li class="item item-header flexrow">
+            <div class="item-name">Nombre</div>
+            <div class="item-prop">Cant.</div>
+            <div class="item-prop detail">
+              {{#if (eq section.type "equipment")}}
+                Slot
+              {{else}}
+                {{#if (eq section.type "consumable")}}
+                  Usos
+                {{else}}
+                  Detalle
+                {{/if}}
+              {{/if}}
+            </div>
+            <div class="item-prop notes">Notas</div>
+            <div class="item-controls"></div>
+          </li>
+
+          {{#each section.items as |item|}}
+            <li class="item flexrow" data-item-id="{{item.id}}">
+              <div class="item-name"><a data-action="edit-item">{{item.name}}</a></div>
+              <div class="item-prop">{{item.system.quantity}}</div>
+              <div class="item-prop detail">
+                {{#if (eq ../section.type "equipment")}}
+                  {{#if item.system.slot}}
+                    {{item.system.slot}}
+                  {{else}}
+                    —
+                  {{/if}}
+                {{else}}
+                  {{#if (eq ../section.type "consumable")}}
+                    {{#if item.system.uses}}
+                      {{item.system.uses.value}}/{{item.system.uses.max}}
+                    {{else}}
+                      —
+                    {{/if}}
+                  {{else}}
+                    {{#if item.system.effect}}
+                      {{item.system.effect}}
+                    {{else}}
+                      —
+                    {{/if}}
+                  {{/if}}
+                {{/if}}
+              </div>
+              <div class="item-prop notes">
+                {{#if item.system.notes}}
+                  {{item.system.notes}}
+                {{else}}
+                  —
+                {{/if}}
+              </div>
+              <div class="item-controls">
+                <a data-action="edit-item" title="Editar"><i class="fas fa-edit"></i></a>
+                <a data-action="delete-item" title="Eliminar"><i class="fas fa-trash"></i></a>
+              </div>
+            </li>
+
+            {{#if (or item.system.description item.system.effect)}}
+              <li class="item item-summary">
+                {{#if item.system.description}}
+                  <div class="item-effect">{{item.system.description}}</div>
+                {{/if}}
+                {{#if item.system.effect}}
+                  <div class="item-effect"><strong>Efecto:</strong> {{item.system.effect}}</div>
+                {{/if}}
+              </li>
+            {{/if}}
+          {{/each}}
+        </ol>
+      {{else}}
+        <p class="notes">{{section.emptyHint}}</p>
+      {{/if}}
+    </div>
+  {{/each}}
 </div>
   </section>
 </form>

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -1,0 +1,66 @@
+<form class="{{cssClass}} my-item-sheet" autocomplete="off">
+  <header class="sheet-header flexrow">
+    <div class="header-fields">
+      <label>Nombre del objeto</label>
+      <input type="text" name="name" value="{{item.name}}"/>
+    </div>
+  </header>
+
+  <nav class="sheet-tabs tabs" data-group="primary">
+    <a class="item" data-tab="details">Detalles</a>
+    <a class="item" data-tab="description">Descripción</a>
+  </nav>
+
+  <section class="sheet-body">
+    <div class="tab" data-tab="details" data-group="primary">
+      <div class="grid two-col">
+        <div class="field">
+          <label>Cantidad</label>
+          <input type="number" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" min="0"/>
+        </div>
+        <div class="field">
+          <label>Valor</label>
+          <input type="number" name="system.value" value="{{system.value}}" data-dtype="Number" min="0" step="1"/>
+        </div>
+
+        <div class="field">
+          <label>Peso</label>
+          <input type="number" name="system.weight" value="{{system.weight}}" data-dtype="Number" min="0" step="0.1"/>
+        </div>
+        <div class="field">
+          <label>Notas breves</label>
+          <input type="text" name="system.notes" value="{{system.notes}}"/>
+        </div>
+
+        {{#if isEquipment}}
+          <div class="field full-width">
+            <label>Slot / Ubicación</label>
+            <input type="text" name="system.slot" value="{{system.slot}}"/>
+          </div>
+        {{/if}}
+
+        {{#if isConsumable}}
+          <div class="field">
+            <label>Usos actuales</label>
+            <input type="number" name="system.uses.value" value="{{system.uses.value}}" data-dtype="Number" min="0"/>
+          </div>
+          <div class="field">
+            <label>Usos máximos</label>
+            <input type="number" name="system.uses.max" value="{{system.uses.max}}" data-dtype="Number" min="0"/>
+          </div>
+        {{/if}}
+      </div>
+    </div>
+
+    <div class="tab" data-tab="description" data-group="primary">
+      <div class="field">
+        <label>Descripción</label>
+        <textarea name="system.description" rows="5">{{system.description}}</textarea>
+      </div>
+      <div class="field">
+        <label>Efecto</label>
+        <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
+      </div>
+    </div>
+  </section>
+</form>


### PR DESCRIPTION
## Summary
- add an Objetos tab to the actor sheet with controls to create, edit and delete categorized items
- introduce equipment, consumable and gear item types with dedicated defaults and data sanitizing
- create a generic item sheet template plus styling updates and register the new item class and sheet

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccae9981f8832baa4ab27ac5e02730