### PR TITLE
Add traits tab and enhance item behaviors

### DIFF
--- a/module/init.js
+++ b/module/init.js
@@ -21,7 +21,7 @@ Hooks.once("init", function () {
   // Items (movimientos y objetos)
   CONFIG.Item.documentClass = PMDItem;
   Items.registerSheet("PMD-Explorers-of-Fate", PMDItemSheet, {
-    types: ["move", "equipment", "consumable", "gear"],
+    types: ["move", "equipment", "consumable", "gear", "trait"],
     makeDefault: true,
     label: "Objeto PMD"
   });

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -26,6 +26,7 @@ export class PMDItemSheet extends ItemSheet {
     data.isEquipment = this.item.type === "equipment";
     data.isConsumable = this.item.type === "consumable";
     data.isGear = this.item.type === "gear";
+    data.isTrait = this.item.type === "trait";
     data.itemType = this.item.type;
     return data;
   }

--- a/module/item.js
+++ b/module/item.js
@@ -58,6 +58,12 @@ export class PMDItem extends Item {
         }
         break;
       }
+
+      case "trait": {
+        const str = (v) => String(v ?? "");
+        sys.effect = str(sys.effect);
+        break;
+      }
     }
   }
 }

--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -55,8 +55,8 @@
   box-sizing: border-box;
 }
 
-/* === Botón que se ve como enlace (para lanzar habilidades) === */
-.my-sheet .skill-label .as-link {
+/* === Botón que se ve como enlace === */
+.PMD-Explorers-of-Fate .as-link {
   background: none;
   border: 0;
   padding: 0;
@@ -67,7 +67,7 @@
   text-decoration: none;
 }
 
-.my-sheet .skill-label .as-link:hover {
+.PMD-Explorers-of-Fate .as-link:hover {
   text-decoration: underline;
 }
 

--- a/template.json
+++ b/template.json
@@ -41,7 +41,7 @@
     }
   },
   "Item": {
-    "types": ["move", "equipment", "consumable", "gear"],
+    "types": ["move", "equipment", "consumable", "gear", "trait"],
     "templates": {
       "baseObject": {
         "quantity": 1,
@@ -71,6 +71,9 @@
     },
     "gear": {
       "templates": ["baseObject"]
+    },
+    "trait": {
+      "effect": ""
     }
   }
 }

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -49,6 +49,7 @@
     <a class="item" data-tab="stats">Atributos</a>
     <a class="item" data-tab="skills">Habilidades</a>
     <a class="item" data-tab="moves">Movimientos</a>
+    <a class="item" data-tab="traits">Rasgos</a>
     <a class="item" data-tab="inventory">Objetos</a>
   </nav>
 
@@ -211,6 +212,43 @@
   {{/if}}
 </div>
 
+    <!-- ===== TAB: Rasgos ===== -->
+    <div class="tab" data-tab="traits" data-group="primary">
+      <div class="flexrow" style="justify-content: space-between; align-items: center; margin-bottom: 6px;">
+        <h3 style="margin:0;">Rasgos</h3>
+        <button type="button" data-action="create-item" data-type="trait">+ Nuevo rasgo</button>
+      </div>
+
+      {{#if traits.length}}
+        <ol class="item-list">
+          <li class="item item-header flexrow">
+            <div class="item-name">Nombre</div>
+            <div class="item-prop notes">Efecto</div>
+            <div class="item-controls"></div>
+          </li>
+
+          {{#each traits as |trait|}}
+            <li class="item flexrow" data-item-id="{{trait.id}}">
+              <div class="item-name"><a data-action="edit-item">{{trait.name}}</a></div>
+              <div class="item-prop notes">
+                {{#if trait.system.effect}}
+                  {{trait.system.effect}}
+                {{else}}
+                  —
+                {{/if}}
+              </div>
+              <div class="item-controls">
+                <a data-action="edit-item" title="Editar"><i class="fas fa-edit"></i></a>
+                <a data-action="delete-item" title="Eliminar"><i class="fas fa-trash"></i></a>
+              </div>
+            </li>
+          {{/each}}
+        </ol>
+      {{else}}
+        <p class="notes">Añade rasgos para registrar efectos especiales o talentos del personaje.</p>
+      {{/if}}
+    </div>
+
 <!-- ===== TAB: Objetos ===== -->
 <div class="tab" data-tab="inventory" data-group="primary">
   {{#each inventorySections as |section|}}
@@ -221,77 +259,96 @@
       </div>
 
       {{#if section.items.length}}
-        <ol class="item-list">
-          <li class="item item-header flexrow">
-            <div class="item-name">Nombre</div>
-            <div class="item-prop">Cant.</div>
-            <div class="item-prop detail">
-              {{#if (eq section.type "equipment")}}
-                Slot
-              {{else}}
-                {{#if (eq section.type "consumable")}}
-                  Usos
-                {{else}}
-                  Detalle
-                {{/if}}
-              {{/if}}
-            </div>
-            <div class="item-prop notes">Notas</div>
-            <div class="item-controls"></div>
-          </li>
+        {{#if (eq section.type "equipment")}}
+          <ol class="item-list">
+            <li class="item item-header flexrow">
+              <div class="item-name">Nombre</div>
+              <div class="item-prop">Valor</div>
+              <div class="item-prop notes">Efecto</div>
+              <div class="item-controls"></div>
+            </li>
 
-          {{#each section.items as |item|}}
-            <li class="item flexrow" data-item-id="{{item.id}}">
-              <div class="item-name"><a data-action="edit-item">{{item.name}}</a></div>
-              <div class="item-prop">{{item.system.quantity}}</div>
-              <div class="item-prop detail">
-                {{#if (eq ../section.type "equipment")}}
-                  {{#if item.system.slot}}
-                    {{item.system.slot}}
+            {{#each section.items as |item|}}
+              <li class="item flexrow" data-item-id="{{item.id}}">
+                <div class="item-name"><a data-action="edit-item">{{item.name}}</a></div>
+                <div class="item-prop">{{item.system.value}}</div>
+                <div class="item-prop notes">
+                  {{#if item.system.effect}}
+                    {{item.system.effect}}
                   {{else}}
                     —
                   {{/if}}
-                {{else}}
-                  {{#if (eq ../section.type "consumable")}}
-                    {{#if item.system.uses}}
-                      {{item.system.uses.value}}/{{item.system.uses.max}}
-                    {{else}}
-                      —
-                    {{/if}}
-                  {{else}}
+                </div>
+                <div class="item-controls">
+                  <a data-action="edit-item" title="Editar"><i class="fas fa-edit"></i></a>
+                  <a data-action="delete-item" title="Eliminar"><i class="fas fa-trash"></i></a>
+                </div>
+              </li>
+            {{/each}}
+          </ol>
+        {{else}}
+          {{#if (eq section.type "consumable")}}
+            <ol class="item-list">
+              <li class="item item-header flexrow">
+                <div class="item-name">Nombre</div>
+                <div class="item-prop">Cant.</div>
+                <div class="item-prop">Valor</div>
+                <div class="item-prop notes">Efecto</div>
+                <div class="item-controls"></div>
+              </li>
+
+              {{#each section.items as |item|}}
+                <li class="item flexrow" data-item-id="{{item.id}}">
+                  <div class="item-name">
+                    <button type="button" class="as-link" data-action="use-consumable">{{item.name}}</button>
+                  </div>
+                  <div class="item-prop">{{item.system.quantity}}</div>
+                  <div class="item-prop">{{item.system.value}}</div>
+                  <div class="item-prop notes">
                     {{#if item.system.effect}}
                       {{item.system.effect}}
                     {{else}}
                       —
                     {{/if}}
-                  {{/if}}
-                {{/if}}
-              </div>
-              <div class="item-prop notes">
-                {{#if item.system.notes}}
-                  {{item.system.notes}}
-                {{else}}
-                  —
-                {{/if}}
-              </div>
-              <div class="item-controls">
-                <a data-action="edit-item" title="Editar"><i class="fas fa-edit"></i></a>
-                <a data-action="delete-item" title="Eliminar"><i class="fas fa-trash"></i></a>
-              </div>
-            </li>
-
-            {{#if (or item.system.description item.system.effect)}}
-              <li class="item item-summary">
-                {{#if item.system.description}}
-                  <div class="item-effect">{{item.system.description}}</div>
-                {{/if}}
-                {{#if item.system.effect}}
-                  <div class="item-effect"><strong>Efecto:</strong> {{item.system.effect}}</div>
-                {{/if}}
+                  </div>
+                  <div class="item-controls">
+                    <a data-action="edit-item" title="Editar"><i class="fas fa-edit"></i></a>
+                    <a data-action="delete-item" title="Eliminar"><i class="fas fa-trash"></i></a>
+                  </div>
+                </li>
+              {{/each}}
+            </ol>
+          {{else}}
+            <ol class="item-list">
+              <li class="item item-header flexrow">
+                <div class="item-name">Nombre</div>
+                <div class="item-prop">Cant.</div>
+                <div class="item-prop">Valor</div>
+                <div class="item-controls"></div>
               </li>
-            {{/if}}
-          {{/each}}
-        </ol>
+
+              {{#each section.items as |item|}}
+                <li class="item flexrow" data-item-id="{{item.id}}">
+                  <div class="item-name">
+                    <button type="button" class="as-link" data-action="use-gear">{{item.name}}</button>
+                  </div>
+                  <div class="item-prop">{{item.system.quantity}}</div>
+                  <div class="item-prop">{{item.system.value}}</div>
+                  <div class="item-controls">
+                    <a data-action="edit-item" title="Editar"><i class="fas fa-edit"></i></a>
+                    <a data-action="delete-item" title="Eliminar"><i class="fas fa-trash"></i></a>
+                  </div>
+                </li>
+
+                {{#if item.system.description}}
+                  <li class="item item-summary">
+                    <div class="item-effect"><strong>Descripción:</strong> {{item.system.description}}</div>
+                  </li>
+                {{/if}}
+              {{/each}}
+            </ol>
+          {{/if}}
+        {{/if}}
       {{else}}
         <p class="notes">{{section.emptyHint}}</p>
       {{/if}}

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -14,53 +14,42 @@
   <section class="sheet-body">
     <div class="tab" data-tab="details" data-group="primary">
       <div class="grid two-col">
-        <div class="field">
-          <label>Cantidad</label>
-          <input type="number" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" min="0"/>
-        </div>
-        <div class="field">
-          <label>Valor</label>
-          <input type="number" name="system.value" value="{{system.value}}" data-dtype="Number" min="0" step="1"/>
-        </div>
-
-        <div class="field">
-          <label>Peso</label>
-          <input type="number" name="system.weight" value="{{system.weight}}" data-dtype="Number" min="0" step="0.1"/>
-        </div>
-        <div class="field">
-          <label>Notas breves</label>
-          <input type="text" name="system.notes" value="{{system.notes}}"/>
-        </div>
-
-        {{#if isEquipment}}
-          <div class="field full-width">
-            <label>Slot / Ubicación</label>
-            <input type="text" name="system.slot" value="{{system.slot}}"/>
+        {{#if (or isConsumable isGear)}}
+          <div class="field">
+            <label>Cantidad</label>
+            <input type="number" name="system.quantity" value="{{system.quantity}}" data-dtype="Number" min="0"/>
           </div>
         {{/if}}
 
-        {{#if isConsumable}}
+        {{#if (or isConsumable isGear isEquipment)}}
           <div class="field">
-            <label>Usos actuales</label>
-            <input type="number" name="system.uses.value" value="{{system.uses.value}}" data-dtype="Number" min="0"/>
+            <label>Valor</label>
+            <input type="number" name="system.value" value="{{system.value}}" data-dtype="Number" min="0" step="1"/>
           </div>
-          <div class="field">
-            <label>Usos máximos</label>
-            <input type="number" name="system.uses.max" value="{{system.uses.max}}" data-dtype="Number" min="0"/>
+        {{/if}}
+
+        {{#if isTrait}}
+          <div class="field full-width">
+            <p class="notes">Los rasgos solo requieren un nombre y su efecto.</p>
           </div>
         {{/if}}
       </div>
     </div>
 
     <div class="tab" data-tab="description" data-group="primary">
-      <div class="field">
-        <label>Descripción</label>
-        <textarea name="system.description" rows="5">{{system.description}}</textarea>
-      </div>
-      <div class="field">
-        <label>Efecto</label>
-        <textarea name="system.effect" rows="4">{{system.effect}}</textarea>
-      </div>
+      {{#if isGear}}
+        <div class="field">
+          <label>Descripción</label>
+          <textarea name="system.description" rows="5">{{system.description}}</textarea>
+        </div>
+      {{/if}}
+
+      {{#if (or isConsumable isEquipment isTrait)}}
+        <div class="field">
+          <label>Efecto</label>
+          <textarea name="system.effect" rows="5">{{system.effect}}</textarea>
+        </div>
+      {{/if}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
## Summary
- add a dedicated Rasgos tab that lists trait items with quick creation controls
- redesign inventory listings to show the required fields per item type and enable consumable/gear usage interactions
- extend item sheets and system definitions to support the new trait type and revised consumable/equipment data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccb674cc98832b904e8912a074b7c9