### PR TITLE
Enable active effects on actors and items

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -17,6 +17,8 @@ export class MyActorSheet extends ActorSheet {
   getData(options) {
     const data = super.getData(options);
     data.system = this.actor.system;
+    data.effects = Array.from(this.actor.effects ?? []);
+    data.isEditable = this.isEditable;
 
     data.skillList = [
       { key: "athletics",   label: "Athletics" },

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -28,6 +28,8 @@ export class PMDItemSheet extends ItemSheet {
     data.isGear = this.item.type === "gear";
     data.isTrait = this.item.type === "trait";
     data.itemType = this.item.type;
+    data.effects = Array.from(this.item.effects ?? []);
+    data.isEditable = this.isEditable;
     return data;
   }
 }

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -51,6 +51,7 @@
     <a class="item" data-tab="moves">Movimientos</a>
     <a class="item" data-tab="traits">Rasgos</a>
     <a class="item" data-tab="inventory">Objetos</a>
+    <a class="item" data-tab="effects">Efectos</a>
   </nav>
 
   <section class="sheet-body">
@@ -249,8 +250,13 @@
       {{/if}}
     </div>
 
-<!-- ===== TAB: Objetos ===== -->
-<div class="tab" data-tab="inventory" data-group="primary">
+    <!-- ===== TAB: Efectos ===== -->
+    <div class="tab" data-tab="effects" data-group="primary">
+      {{> "systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs" effects=effects document=actor isEditable=isEditable}}
+    </div>
+
+    <!-- ===== TAB: Objetos ===== -->
+    <div class="tab" data-tab="inventory" data-group="primary">
   {{#each inventorySections as |section|}}
     <div class="inventory-section">
       <div class="flexrow" style="justify-content: space-between; align-items: center; margin: 12px 0 6px;">
@@ -354,6 +360,6 @@
       {{/if}}
     </div>
   {{/each}}
-</div>
+    </div>
   </section>
 </form>

--- a/templates/item-move-sheet.hbs
+++ b/templates/item-move-sheet.hbs
@@ -9,6 +9,7 @@
   <nav class="sheet-tabs tabs" data-group="primary">
     <a class="item" data-tab="details">Detalles</a>
     <a class="item" data-tab="text">Texto</a>
+    <a class="item" data-tab="effects">Efectos</a>
   </nav>
 
   <section class="sheet-body">
@@ -56,6 +57,10 @@
         <label>Efecto (opcional)</label>
         <textarea name="system.effect" rows="6">{{system.effect}}</textarea>
       </div>
+    </div>
+
+    <div class="tab" data-tab="effects" data-group="primary">
+      {{> "systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs" effects=effects document=item isEditable=isEditable}}
     </div>
   </section>
 </form>

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -9,6 +9,7 @@
   <nav class="sheet-tabs tabs" data-group="primary">
     <a class="item" data-tab="details">Detalles</a>
     <a class="item" data-tab="description">Descripción</a>
+    <a class="item" data-tab="effects">Efectos</a>
   </nav>
 
   <section class="sheet-body">
@@ -50,6 +51,10 @@
           <textarea name="system.effect" rows="5">{{system.effect}}</textarea>
         </div>
       {{/if}}
+    </div>
+
+    <div class="tab" data-tab="effects" data-group="primary">
+      {{> "systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs" effects=effects document=item isEditable=isEditable}}
     </div>
   </section>
 </form>

--- a/templates/parts/active-effects.hbs
+++ b/templates/parts/active-effects.hbs
@@ -1,0 +1,63 @@
+<section class="effects-panel">
+  <header class="effects-header flexrow" style="align-items: center; gap: 8px;">
+    <h3 style="margin: 0;">Efectos activos</h3>
+    {{#if isEditable}}
+      <button type="button" class="effect-control" data-action="create">
+        <i class="fas fa-plus"></i>
+        Nuevo efecto
+      </button>
+    {{/if}}
+  </header>
+
+  {{#if effects.length}}
+    <ol class="effects-list directory-list">
+      {{#each effects}}
+        <li class="effect flexcol {{#if this.disabled}}inactive{{/if}}" data-effect-id="{{this.id}}">
+          <div class="effect-header flexrow" style="justify-content: space-between; align-items: center; gap: 8px;">
+            <div class="effect-title flexrow" style="align-items: center; gap: 6px;">
+              {{#if this.icon}}
+                <img src="{{this.icon}}" alt="{{this.name}}" class="effect-icon" width="24" height="24"/>
+              {{/if}}
+              <span class="effect-name">{{this.name}}</span>
+            </div>
+            {{#if ../isEditable}}
+              <div class="effect-controls flexrow" style="gap: 6px;">
+                <a class="effect-control" data-action="toggle" title="{{#if this.disabled}}Activar{{else}}Desactivar{{/if}}">
+                  <i class="fas {{#if this.disabled}}fa-toggle-off{{else}}fa-toggle-on{{/if}}"></i>
+                </a>
+                <a class="effect-control" data-action="edit" title="Editar">
+                  <i class="fas fa-edit"></i>
+                </a>
+                <a class="effect-control" data-action="delete" title="Eliminar">
+                  <i class="fas fa-trash"></i>
+                </a>
+              </div>
+            {{/if}}
+          </div>
+
+          {{#if this.description}}
+            <p class="effect-description">{{{this.description}}}</p>
+          {{/if}}
+
+          {{#if this.changes}}
+            <ul class="effect-changes">
+              {{#each this.changes}}
+                <li>
+                  <span class="change-key">{{this.key}}</span>
+                  <span class="change-mode">{{this.mode}}</span>
+                  <span class="change-value">{{this.value}}</span>
+                </li>
+              {{/each}}
+            </ul>
+          {{/if}}
+
+          {{#if this.origin}}
+            <p class="effect-origin"><strong>Origen:</strong> {{this.origin}}</p>
+          {{/if}}
+        </li>
+      {{/each}}
+    </ol>
+  {{else}}
+    <p class="notes">No hay efectos activos.</p>
+  {{/if}}
+</section>


### PR DESCRIPTION
## Summary
- add Active Effects tab to the actor sheet with a reusable partial for effect management
- expose the Active Effects tab on item sheets and pass the necessary data context
- create a shared Active Effects template with controls to create, toggle, edit, and delete effects

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd8b4166fc832bbe445858dc661ccf