### PR TITLE
Add access to active effects from sheets

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -75,6 +75,18 @@ export class MyActorSheet extends ActorSheet {
   /** @override */
   activateListeners(html) {
     super.activateListeners(html);
+
+    html.find("[data-action='manage-effects']").on("click", (ev) => {
+      ev.preventDefault();
+      if (!this.isEditable) return;
+      const Config = globalThis?.ActiveEffectsConfig ?? null;
+      if (Config) {
+        new Config(this.actor).render(true);
+      } else {
+        ui.notifications?.error("No se pudo abrir la configuración de efectos activos.");
+      }
+    });
+
     if (!this.isEditable) return;
 
     // Habilidades

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -30,4 +30,19 @@ export class PMDItemSheet extends ItemSheet {
     data.itemType = this.item.type;
     return data;
   }
+
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    html.find("[data-action='manage-effects']").on("click", (ev) => {
+      ev.preventDefault();
+      if (!this.isEditable) return;
+      const Config = globalThis?.ActiveEffectsConfig ?? null;
+      if (Config) {
+        new Config(this.item).render(true);
+      } else {
+        ui.notifications?.error("No se pudo abrir la configuración de efectos activos.");
+      }
+    });
+  }
 }

--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -9,6 +9,36 @@
   flex: 1;
 }
 
+.my-sheet .sheet-header,
+.PMD-Explorers-of-Fate.sheet.item .sheet-header {
+  align-items: flex-start;
+}
+
+.my-sheet .sheet-header .header-controls,
+.PMD-Explorers-of-Fate.sheet.item .sheet-header .header-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  margin-left: 12px;
+}
+
+.PMD-Explorers-of-Fate .effects-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.2));
+  border-radius: 4px;
+  background: var(--color-bg-option, rgba(0, 0, 0, 0.05));
+  color: inherit;
+  cursor: pointer;
+}
+
+.PMD-Explorers-of-Fate .effects-control:hover {
+  background: var(--color-bg-btn-hover, rgba(0, 0, 0, 0.1));
+}
+
 .my-sheet .grid.two-col,
 .PMD-Explorers-of-Fate.sheet.item .grid.two-col {
   display: grid;

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -42,6 +42,13 @@
         </div>
       </div>
     </div>
+
+    <div class="header-controls">
+      <button type="button" data-action="manage-effects" class="effects-control" title="Gestionar efectos activos">
+        <i class="fas fa-magic" aria-hidden="true"></i>
+        <span>Efectos activos</span>
+      </button>
+    </div>
   </header>
 
   <!-- ===== Tabs ===== -->

--- a/templates/item-move-sheet.hbs
+++ b/templates/item-move-sheet.hbs
@@ -4,6 +4,12 @@
       <label>Nombre del movimiento</label>
       <input type="text" name="name" value="{{item.name}}"/>
     </div>
+    <div class="header-controls">
+      <button type="button" data-action="manage-effects" class="effects-control" title="Gestionar efectos activos">
+        <i class="fas fa-magic" aria-hidden="true"></i>
+        <span>Efectos activos</span>
+      </button>
+    </div>
   </header>
 
   <nav class="sheet-tabs tabs" data-group="primary">

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -4,6 +4,12 @@
       <label>Nombre del objeto</label>
       <input type="text" name="name" value="{{item.name}}"/>
     </div>
+    <div class="header-controls">
+      <button type="button" data-action="manage-effects" class="effects-control" title="Gestionar efectos activos">
+        <i class="fas fa-magic" aria-hidden="true"></i>
+        <span>Efectos activos</span>
+      </button>
+    </div>
   </header>
 
   <nav class="sheet-tabs tabs" data-group="primary">


### PR DESCRIPTION
## Summary
- add an Active Effects management button to actor and item sheet headers
- hook the new controls to Foundry's ActiveEffectsConfig with a safe fallback
- style the header controls for consistent layout across sheets

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd93c4740c832b913d97fe8a76ee30