### PR TITLE
Migrar hojas a Application V2

### DIFF
--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -1,14 +1,40 @@
 // module/item-sheet.js
-export class PMDItemSheet extends ItemSheet {
+const BaseItemSheet = foundry?.applications?.sheets?.ItemSheet ?? ItemSheet;
+
+function cloneDefaults(defaults) {
+  if (!defaults) return {};
+  if (foundry?.utils?.deepClone) return foundry.utils.deepClone(defaults);
+  if (typeof structuredClone === "function") return structuredClone(defaults);
+  try {
+    return JSON.parse(JSON.stringify(defaults));
+  } catch (err) {
+    if (foundry?.utils?.mergeObject) return foundry.utils.mergeObject({}, defaults);
+    return { ...defaults };
+  }
+}
+
+function createItemSheetOptions() {
+  return {
+    classes: ["PMD-Explorers-of-Fate", "sheet", "item"],
+    width: 480,
+    height: 420,
+    tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "details" }],
+    submitOnChange: true,
+    closeOnSubmit: false
+  };
+}
+
+export class PMDItemSheet extends BaseItemSheet {
+  static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+    cloneDefaults(super.DEFAULT_OPTIONS ?? super.defaultOptions),
+    createItemSheetOptions()
+  );
+
   static get defaultOptions() {
-    return foundry.utils.mergeObject(super.defaultOptions, {
-      classes: ["PMD-Explorers-of-Fate", "sheet", "item"],
-      width: 480,
-      height: 420,
-      tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "details" }],
-      submitOnChange: true,
-      closeOnSubmit: false
-    });
+    if (super.defaultOptions) {
+      return foundry.utils.mergeObject(cloneDefaults(super.defaultOptions), createItemSheetOptions());
+    }
+    return this.DEFAULT_OPTIONS;
   }
 
   /** @override */
@@ -19,8 +45,34 @@ export class PMDItemSheet extends ItemSheet {
     return "systems/PMD-Explorers-of-Fate/templates/item-object-sheet.hbs";
   }
 
-  getData(options) {
-    const data = super.getData(options);
+  async _prepareContext(options) {
+    const context = await this._getBaseContext(options, true);
+    return this._augmentContext(context);
+  }
+
+  async getData(options = {}) {
+    const context = await this._getBaseContext(options, false);
+    return this._augmentContext(context);
+  }
+
+  async _getBaseContext(options, preferV2) {
+    if (preferV2 && typeof super._prepareContext === "function") {
+      return await super._prepareContext(options);
+    }
+    if (!preferV2 && typeof super.getData === "function") {
+      return await super.getData(options);
+    }
+    if (typeof super._prepareContext === "function") {
+      return await super._prepareContext(options);
+    }
+    if (typeof super.getData === "function") {
+      return await super.getData(options);
+    }
+    return {};
+  }
+
+  _augmentContext(context) {
+    const data = context ?? {};
     data.system = this.item.system;
     data.isMove = this.item.type === "move";
     data.isEquipment = this.item.type === "equipment";


### PR DESCRIPTION
## Summary
- Actualizar `MyActorSheet` y `PMDItemSheet` para extender las clases basadas en Application V2 y generar el contexto mediante `_prepareContext` manteniendo compatibilidad retro.
- Reemplazar los listeners con jQuery por manejadores DOM nativos y utilidades auxiliares compatibles con la nueva arquitectura.
- Ajustar diálogos y formularios para resolver valores sin depender de jQuery.

## Testing
- No se ejecutaron pruebas (no hay scripts definidos).


------
https://chatgpt.com/codex/tasks/task_e_68cda0236538832b977de928c7d69432