### PR TITLE
Fix Foundry v13 namespace warnings

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -1,5 +1,8 @@
 // module/actor-sheet.js
-const BaseActorSheet = foundry?.applications?.sheets?.ActorSheet ?? ActorSheet;
+const BaseActorSheet =
+  foundry?.appv1?.sheets?.ActorSheet ??
+  foundry?.applications?.sheets?.ActorSheet ??
+  globalThis.ActorSheet;
 
 function cloneDefaults(defaults) {
   if (!defaults) return {};

--- a/module/init.js
+++ b/module/init.js
@@ -16,21 +16,34 @@ Hooks.once("init", function () {
     decimals: 0
   };
 
+  const actorCollection = foundry?.documents?.collections?.Actors ?? globalThis.Actors;
+  const coreActorSheet =
+    foundry?.appv1?.sheets?.ActorSheet ??
+    foundry?.applications?.sheets?.ActorSheet ??
+    globalThis.ActorSheet;
+
   // Registrar hoja por defecto para nuestro tipo
-  Actors.unregisterSheet("core", ActorSheet);
-  Actors.registerSheet("PMD-Explorers-of-Fate", MyActorSheet, {
-    types: ["creature"],
-    makeDefault: true,
-    label: "Hoja de Criatura (Básica)"
-  });
+  if (actorCollection?.unregisterSheet && coreActorSheet) {
+    actorCollection.unregisterSheet("core", coreActorSheet);
+  }
+  if (actorCollection?.registerSheet) {
+    actorCollection.registerSheet("PMD-Explorers-of-Fate", MyActorSheet, {
+      types: ["creature"],
+      makeDefault: true,
+      label: "Hoja de Criatura (Básica)"
+    });
+  }
 
   // Items (movimientos y objetos)
   CONFIG.Item.documentClass = PMDItem;
-  Items.registerSheet("PMD-Explorers-of-Fate", PMDItemSheet, {
-    types: ["move", "equipment", "consumable", "gear", "trait"],
-    makeDefault: true,
-    label: "Objeto PMD"
-  });
+  const itemCollection = foundry?.documents?.collections?.Items ?? globalThis.Items;
+  if (itemCollection?.registerSheet) {
+    itemCollection.registerSheet("PMD-Explorers-of-Fate", PMDItemSheet, {
+      types: ["move", "equipment", "consumable", "gear", "trait"],
+      makeDefault: true,
+      label: "Objeto PMD"
+    });
+  }
 });
 
 Hooks.once("ready", function () {

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -1,5 +1,8 @@
 // module/item-sheet.js
-const BaseItemSheet = foundry?.applications?.sheets?.ItemSheet ?? ItemSheet;
+const BaseItemSheet =
+  foundry?.appv1?.sheets?.ItemSheet ??
+  foundry?.applications?.sheets?.ItemSheet ??
+  globalThis.ItemSheet;
 
 function cloneDefaults(defaults) {
   if (!defaults) return {};


### PR DESCRIPTION
## Summary
- update sheet registration to use Foundry's namespaced document collections
- resolve actor and item sheet base classes from the new appv1 namespace with legacy fallbacks

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdcd21b66c832bbca3c486feb9daf7