### PR TITLE
Add Pokémon type sliders and automated STAB detection

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -1,4 +1,5 @@
 // module/actor.js
+import { normalizeTypeValue } from "./pokemon-types.js";
 export class MyActor extends Actor {
   /** @override */
   prepareDerivedData() {
@@ -20,8 +21,8 @@ export class MyActor extends Actor {
     sys.stab        = num(sys.stab, 0);
     sys.basicattack = num(sys.basicattack, 0);
     sys.belly       = num(sys.belly, 100);
-    sys.type1 = String(sys.type1 ?? "");
-    sys.type2 = String(sys.type2 ?? "");
+    sys.type1 = normalizeTypeValue(sys.type1);
+    sys.type2 = normalizeTypeValue(sys.type2);
     sys.pasiva = String(sys.pasiva ?? "");
     sys.destino = String(sys.destino ?? "");
     sys.leyenda = String(sys.leyenda ?? "");

--- a/module/item.js
+++ b/module/item.js
@@ -1,4 +1,5 @@
 // module/item.js
+import { normalizeTypeValue } from "./pokemon-types.js";
 export class PMDItem extends Item {
   /** @override */
   prepareDerivedData() {
@@ -28,7 +29,7 @@ export class PMDItem extends Item {
 
         // Strings seguros
         sys.range   = String(sys.range ?? "");
-        sys.element = String(sys.element ?? "");
+        sys.element = normalizeTypeValue(sys.element);
         sys.effect  = String(sys.effect ?? "");
         break;
       }

--- a/module/pokemon-types.js
+++ b/module/pokemon-types.js
@@ -1,0 +1,68 @@
+const RAW_TYPE_OPTIONS = [
+  { value: "", label: "Sin tipo" },
+  { value: "Normal", label: "Normal" },
+  { value: "Fuego", label: "Fuego" },
+  { value: "Agua", label: "Agua" },
+  { value: "Planta", label: "Planta" },
+  { value: "Eléctrico", label: "Eléctrico" },
+  { value: "Hielo", label: "Hielo" },
+  { value: "Lucha", label: "Lucha" },
+  { value: "Veneno", label: "Veneno" },
+  { value: "Tierra", label: "Tierra" },
+  { value: "Volador", label: "Volador" },
+  { value: "Psíquico", label: "Psíquico" },
+  { value: "Bicho", label: "Bicho" },
+  { value: "Roca", label: "Roca" },
+  { value: "Fantasma", label: "Fantasma" },
+  { value: "Dragón", label: "Dragón" },
+  { value: "Siniestro", label: "Siniestro" },
+  { value: "Acero", label: "Acero" },
+  { value: "Hada", label: "Hada" }
+];
+
+export const TYPE_OPTIONS = Object.freeze(RAW_TYPE_OPTIONS.map((opt) => Object.freeze({ ...opt })));
+
+function clampIndex(index) {
+  const max = TYPE_OPTIONS.length - 1;
+  const num = Number(index);
+  if (!Number.isFinite(num)) return 0;
+  const rounded = Math.round(num);
+  if (rounded < 0) return 0;
+  if (rounded > max) return max;
+  return rounded;
+}
+
+function normalizeForMatch(str) {
+  return String(str ?? "")
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+export function typeOptionFromIndex(index) {
+  return TYPE_OPTIONS[clampIndex(index)] ?? TYPE_OPTIONS[0];
+}
+
+export function normalizeTypeValue(value) {
+  const str = String(value ?? "").trim();
+  if (!str) return "";
+  const target = normalizeForMatch(str);
+  const found = TYPE_OPTIONS.find((opt) => normalizeForMatch(opt.value) === target);
+  return found ? found.value : "";
+}
+
+export function typeIndexFromValue(value) {
+  const normalized = normalizeTypeValue(value);
+  const idx = TYPE_OPTIONS.findIndex((opt) => opt.value === normalized);
+  return idx >= 0 ? idx : 0;
+}
+
+export function typeLabelFromValue(value) {
+  const normalized = normalizeTypeValue(value);
+  const found = TYPE_OPTIONS.find((opt) => opt.value === normalized);
+  return found ? found.label : TYPE_OPTIONS[0].label;
+}
+
+export function typeValueFromIndex(index) {
+  return typeOptionFromIndex(index).value;
+}

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -34,12 +34,21 @@
         <!-- Nuevos campos: Tipo 1 y Tipo 2 -->
         <div>
           <label>Tipo 1</label>
-          <input type="text" name="system.type1" value="{{system.type1}}"/>
+          <input type="hidden" name="system.type1" value="{{system.type1}}" data-type-value="type1"/>
+          <input type="range" min="0" max="{{typeMaxIndex}}" value="{{typeIndices.type1}}" step="1" list="actor-type-options-{{actor._id}}" data-type-slider="type1"/>
+          <span class="type-label" data-type-display="type1">{{typeLabels.type1}}</span>
         </div>
         <div>
           <label>Tipo 2</label>
-          <input type="text" name="system.type2" value="{{system.type2}}"/>
+          <input type="hidden" name="system.type2" value="{{system.type2}}" data-type-value="type2"/>
+          <input type="range" min="0" max="{{typeMaxIndex}}" value="{{typeIndices.type2}}" step="1" list="actor-type-options-{{actor._id}}" data-type-slider="type2"/>
+          <span class="type-label" data-type-display="type2">{{typeLabels.type2}}</span>
         </div>
+        <datalist id="actor-type-options-{{actor._id}}">
+          {{#each typeOptions as |option idx|}}
+            <option value="{{idx}}" label="{{option.label}}"></option>
+          {{/each}}
+        </datalist>
       </div>
     </div>
   </header>

--- a/templates/item-move-sheet.hbs
+++ b/templates/item-move-sheet.hbs
@@ -42,8 +42,15 @@
 
         <div class="field">
           <label>Tipo</label>
-          <input type="text" name="system.element" value="{{system.element}}"/>
+          <input type="hidden" name="system.element" value="{{system.element}}" data-move-type-value/>
+          <input type="range" min="0" max="{{typeMaxIndex}}" value="{{typeIndex}}" step="1" list="move-type-options-{{item._id}}" data-move-type-slider/>
+          <span class="type-label" data-move-type-display>{{typeLabel}}</span>
         </div>
+        <datalist id="move-type-options-{{item._id}}">
+          {{#each typeOptions as |option idx|}}
+            <option value="{{idx}}" label="{{option.label}}"></option>
+          {{/each}}
+        </datalist>
         <div class="field">
           <label>Daño base</label>
           <input type="number" name="system.baseDamage" value="{{system.baseDamage}}" data-dtype="Number" min="0"/>


### PR DESCRIPTION
## Summary
- replace text inputs for Pokémon types with range sliders on actor and move sheets, sharing a common type list
- normalize stored type values and automatically display current type labels on both sheets
- detect STAB automatically during damage prompts and inform the user without requesting manual input

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d98f17db88832bb71bb556bc6f9295