### PR TITLE
Add species field and replace actor type slider with selects

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -2,9 +2,7 @@
 import {
   TYPE_OPTIONS,
   normalizeTypeValue,
-  typeIndexFromValue,
-  typeLabelFromValue,
-  typeValueFromIndex
+  typeIndexFromValue
 } from "./pokemon-types.js";
 const BaseActorSheet =
   foundry?.appv1?.sheets?.ActorSheet ??
@@ -99,14 +97,9 @@ export class MyActorSheet extends BaseActorSheet {
     data.system = this.actor.system;
 
     data.typeOptions = TYPE_OPTIONS;
-    data.typeMaxIndex = TYPE_OPTIONS.length - 1;
     data.typeIndices = {
       type1: typeIndexFromValue(this.actor.system?.type1),
       type2: typeIndexFromValue(this.actor.system?.type2)
-    };
-    data.typeLabels = {
-      type1: typeLabelFromValue(this.actor.system?.type1),
-      type2: typeLabelFromValue(this.actor.system?.type2)
     };
 
     data.skillList = [
@@ -171,27 +164,6 @@ export class MyActorSheet extends BaseActorSheet {
 
     const root = resolveHTMLElement(html);
     if (!root || !this.isEditable) return;
-
-    const syncTypeInput = (slider) => {
-      const key = slider.dataset.typeSlider;
-      if (!key) return;
-      const hidden = root.querySelector(`[data-type-value='${key}']`);
-      const display = root.querySelector(`[data-type-display='${key}']`);
-      const value = typeValueFromIndex(slider.value);
-      if (hidden && hidden.value !== value) {
-        hidden.value = value;
-        hidden.dispatchEvent(new Event("change", { bubbles: true }));
-      }
-      if (display) {
-        display.textContent = typeLabelFromValue(value);
-      }
-    };
-
-    root.querySelectorAll("[data-type-slider]").forEach((slider) => {
-      slider.addEventListener("input", () => syncTypeInput(slider));
-      slider.addEventListener("change", () => syncTypeInput(slider));
-      syncTypeInput(slider);
-    });
 
     const addClick = (selector, handler) => {
       root.querySelectorAll(selector).forEach((element) => {

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -7,6 +7,10 @@
 
       <div class="grid two-col">
         <div>
+          <label>Especie</label>
+          <input type="text" name="system.species" value="{{system.species}}" />
+        </div>
+        <div>
           <label>Nivel</label>
           <input type="number" name="system.lvl" value="{{system.lvl}}" data-dtype="Number"/>
         </div>
@@ -34,21 +38,20 @@
         <!-- Nuevos campos: Tipo 1 y Tipo 2 -->
         <div>
           <label>Tipo 1</label>
-          <input type="hidden" name="system.type1" value="{{system.type1}}" data-type-value="type1"/>
-          <input type="range" min="0" max="{{typeMaxIndex}}" value="{{typeIndices.type1}}" step="1" list="actor-type-options-{{actor._id}}" data-type-slider="type1"/>
-          <span class="type-label" data-type-display="type1">{{typeLabels.type1}}</span>
+          <select name="system.type1">
+            {{#each typeOptions as |option idx|}}
+              <option value="{{option.value}}" {{#if (eq idx ../typeIndices.type1)}}selected{{/if}}>{{option.label}}</option>
+            {{/each}}
+          </select>
         </div>
         <div>
           <label>Tipo 2</label>
-          <input type="hidden" name="system.type2" value="{{system.type2}}" data-type-value="type2"/>
-          <input type="range" min="0" max="{{typeMaxIndex}}" value="{{typeIndices.type2}}" step="1" list="actor-type-options-{{actor._id}}" data-type-slider="type2"/>
-          <span class="type-label" data-type-display="type2">{{typeLabels.type2}}</span>
+          <select name="system.type2">
+            {{#each typeOptions as |option idx|}}
+              <option value="{{option.value}}" {{#if (eq idx ../typeIndices.type2)}}selected{{/if}}>{{option.label}}</option>
+            {{/each}}
+          </select>
         </div>
-        <datalist id="actor-type-options-{{actor._id}}">
-          {{#each typeOptions as |option idx|}}
-            <option value="{{idx}}" label="{{option.label}}"></option>
-          {{/each}}
-        </datalist>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- add a free-text "Especie" field to the actor sheet header
- replace the actor type sliders with dropdown selectors bound to the existing type list
- simplify the actor sheet listener setup now that slider syncing is unnecessary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9949cc844832b9d962b2e55036861