### PR TITLE
Replace move type slider with dropdown

### DIFF
--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -1,10 +1,5 @@
 // module/item-sheet.js
-import {
-  TYPE_OPTIONS,
-  typeIndexFromValue,
-  typeLabelFromValue,
-  typeValueFromIndex
-} from "./pokemon-types.js";
+import { TYPE_OPTIONS } from "./pokemon-types.js";
 const BaseItemSheet =
   foundry?.appv1?.sheets?.ItemSheet ??
   foundry?.applications?.sheets?.ItemSheet ??
@@ -90,9 +85,6 @@ export class PMDItemSheet extends BaseItemSheet {
     data.isTrait = this.item.type === "trait";
     data.itemType = this.item.type;
     data.typeOptions = TYPE_OPTIONS;
-    data.typeMaxIndex = TYPE_OPTIONS.length - 1;
-    data.typeIndex = typeIndexFromValue(this.item.system?.element);
-    data.typeLabel = typeLabelFromValue(this.item.system?.element);
     return data;
   }
 
@@ -101,31 +93,5 @@ export class PMDItemSheet extends BaseItemSheet {
     if (typeof super.activateListeners === "function") {
       super.activateListeners(html);
     }
-
-    const raw = html?.element ?? html;
-    const root = raw instanceof HTMLElement || raw instanceof DocumentFragment
-      ? raw
-      : raw?.[0];
-    if (!(root instanceof HTMLElement) && !(root instanceof DocumentFragment)) return;
-    if (!this.isEditable) return;
-
-    const syncTypeInput = (slider) => {
-      const hidden = root.querySelector("[data-move-type-value]");
-      const display = root.querySelector("[data-move-type-display]");
-      const value = typeValueFromIndex(slider.value);
-      if (hidden && hidden.value !== value) {
-        hidden.value = value;
-        hidden.dispatchEvent(new Event("change", { bubbles: true }));
-      }
-      if (display) {
-        display.textContent = typeLabelFromValue(value);
-      }
-    };
-
-    root.querySelectorAll("[data-move-type-slider]").forEach((slider) => {
-      slider.addEventListener("input", () => syncTypeInput(slider));
-      slider.addEventListener("change", () => syncTypeInput(slider));
-      syncTypeInput(slider);
-    });
   }
 }

--- a/templates/item-move-sheet.hbs
+++ b/templates/item-move-sheet.hbs
@@ -42,15 +42,12 @@
 
         <div class="field">
           <label>Tipo</label>
-          <input type="hidden" name="system.element" value="{{system.element}}" data-move-type-value/>
-          <input type="range" min="0" max="{{typeMaxIndex}}" value="{{typeIndex}}" step="1" list="move-type-options-{{item._id}}" data-move-type-slider/>
-          <span class="type-label" data-move-type-display>{{typeLabel}}</span>
+          <select name="system.element">
+            {{#each typeOptions as |option|}}
+              <option value="{{option.value}}" {{#if (eq option.value ../system.element)}}selected{{/if}}>{{option.label}}</option>
+            {{/each}}
+          </select>
         </div>
-        <datalist id="move-type-options-{{item._id}}">
-          {{#each typeOptions as |option idx|}}
-            <option value="{{idx}}" label="{{option.label}}"></option>
-          {{/each}}
-        </datalist>
         <div class="field">
           <label>Daño base</label>
           <input type="number" name="system.baseDamage" value="{{system.baseDamage}}" data-dtype="Number" min="0"/>


### PR DESCRIPTION
## Summary
- replace the move type slider on the move item sheet with a dropdown that reuses the shared type options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d996696dac832b8ee4cbb6f05055f4