### PR TITLE
Add equipped checkbox to equipment items

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -252,6 +252,16 @@ export class MyActorSheet extends BaseActorSheet {
       const item = id ? this.actor.items.get(id) : null;
       if (item) await this._useGearItem(item);
     });
+
+    root.querySelectorAll("[data-action='toggle-equipped']").forEach((element) => {
+      element.addEventListener("change", async () => {
+        const id = element.closest("[data-item-id]")?.dataset.itemId;
+        if (!id) return;
+        const item = this.actor.items.get(id);
+        if (!item) return;
+        await item.update({ "system.equipped": !!element.checked });
+      });
+    });
   }
 
   async _restoreActorResources() {

--- a/template.json
+++ b/template.json
@@ -64,7 +64,8 @@
     },
     "equipment": {
       "templates": ["baseObject"],
-      "slot": ""
+      "slot": "",
+      "equipped": false
     },
     "consumable": {
       "templates": ["baseObject"],

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -276,6 +276,7 @@
             <li class="item item-header flexrow">
               <div class="item-name">Nombre</div>
               <div class="item-prop">Valor</div>
+              <div class="item-prop">Equip.</div>
               <div class="item-prop notes">Efecto</div>
               <div class="item-controls"></div>
             </li>
@@ -284,6 +285,9 @@
               <li class="item flexrow" data-item-id="{{item.id}}">
                 <div class="item-name"><a data-action="edit-item">{{item.name}}</a></div>
                 <div class="item-prop">{{item.system.value}}</div>
+                <div class="item-prop">
+                  <input type="checkbox" data-action="toggle-equipped" {{checked item.system.equipped}} />
+                </div>
                 <div class="item-prop notes">
                   {{#if item.system.effect}}
                     {{item.system.effect}}

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -28,6 +28,13 @@
           </div>
         {{/if}}
 
+        {{#if isEquipment}}
+          <div class="field">
+            <label>Equipado</label>
+            <input type="checkbox" name="system.equipped" {{checked system.equipped}} />
+          </div>
+        {{/if}}
+
         {{#if isTrait}}
           <div class="field full-width">
             <p class="notes">Los rasgos solo requieren un nombre y su efecto.</p>


### PR DESCRIPTION
## Summary
- add an equipped flag to equipment items and expose it on the equipment item sheet
- show an equipped toggle for equipment entries on the actor inventory and persist the state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d998bbbb94832b931ec79e45ca47b1