### PR TITLE
Add equip toggle to consumable items

### DIFF
--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -309,6 +309,7 @@
                 <div class="item-name">Nombre</div>
                 <div class="item-prop">Cant.</div>
                 <div class="item-prop">Valor</div>
+                <div class="item-prop">Equip.</div>
                 <div class="item-prop notes">Efecto</div>
                 <div class="item-controls"></div>
               </li>
@@ -320,6 +321,9 @@
                   </div>
                   <div class="item-prop">{{item.system.quantity}}</div>
                   <div class="item-prop">{{item.system.value}}</div>
+                  <div class="item-prop">
+                    <input type="checkbox" data-action="toggle-equipped" {{checked item.system.equipped}} />
+                  </div>
                   <div class="item-prop notes">
                     {{#if item.system.effect}}
                       {{item.system.effect}}

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -28,7 +28,7 @@
           </div>
         {{/if}}
 
-        {{#if isEquipment}}
+        {{#if (or isEquipment isConsumable)}}
           <div class="field">
             <label>Equipado</label>
             <input type="checkbox" name="system.equipped" {{checked system.equipped}} />


### PR DESCRIPTION
## Summary
- add the equipped checkbox to consumable entries in the inventory list
- allow consumable item sheets to edit the equipped state

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9a300d634832b8e6a47886601c5cc