### PR TITLE
Add Active Effect support

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -5,6 +5,7 @@ import {
   typeIndexFromValue,
   calculateTypeEffectiveness
 } from "./pokemon-types.js";
+import { mapActiveEffects, bindEffectControls } from "./effect-helpers.js";
 const BaseActorSheet =
   foundry?.appv1?.sheets?.ActorSheet ??
   foundry?.applications?.sheets?.ActorSheet ??
@@ -154,6 +155,8 @@ export class MyActorSheet extends BaseActorSheet {
       },
     ];
 
+    data.activeEffects = mapActiveEffects(this.actor);
+
     return data;
   }
 
@@ -263,6 +266,8 @@ export class MyActorSheet extends BaseActorSheet {
         await item.update({ "system.equipped": !!element.checked });
       });
     });
+
+    bindEffectControls(root, this.actor, "actor");
   }
 
   async _restoreActorResources() {

--- a/module/actor.js
+++ b/module/actor.js
@@ -2,11 +2,10 @@
 import { normalizeTypeValue } from "./pokemon-types.js";
 export class MyActor extends Actor {
   /** @override */
-  prepareDerivedData() {
-    super.prepareDerivedData();
+  prepareBaseData() {
+    super.prepareBaseData();
     const sys = this.system;
 
-    // --- Saneo básico de numéricos (evita NaN) ---
     const num = (v, d = 0) => {
       const n = Number(v);
       return Number.isFinite(n) ? n : d;
@@ -21,6 +20,8 @@ export class MyActor extends Actor {
     sys.stab        = num(sys.stab, 0);
     sys.basicattack = num(sys.basicattack, 0);
     sys.belly       = num(sys.belly, 100);
+    sys.lp          = num(sys.lp, 0);
+
     sys.type1 = normalizeTypeValue(sys.type1);
     sys.type2 = normalizeTypeValue(sys.type2);
     sys.pasiva = String(sys.pasiva ?? "");
@@ -28,22 +29,15 @@ export class MyActor extends Actor {
     sys.leyenda = String(sys.leyenda ?? "");
     sys.background = String(sys.background ?? "");
 
-
-    // HP (opcionalmente clamp si lo deseas)
     sys.hp ??= { max: 10, value: 10 };
-    sys.hp.max   = num(sys.hp.max, 10);
+    sys.hp.max = num(sys.hp.max, 10);
     sys.hp.value = num(sys.hp.value, sys.hp.max);
-    sys.hp.value = Math.clamp(sys.hp.value, 0, sys.hp.max);
 
     const level = num(sys.lvl, 1);
     sys.experience ??= { max: level * 100, value: 0 };
     sys.experience.value = num(sys.experience.value, 0);
     sys.experience.max = Math.max(0, level * 100);
-    sys.experience.value = Math.clamp(sys.experience.value, 0, sys.experience.max);
 
-    sys.lp = num(sys.lp, 0);
-
-    // --- Habilidades: asegurar objeto y aplicar límites 15..95 ---
     const SK = [
       "athletics","craft","endurance","finesse","medicine",
       "perception","performance","persuasion","spKnowledge",
@@ -52,6 +46,20 @@ export class MyActor extends Actor {
     sys.skills ??= {};
     for (const k of SK) {
       sys.skills[k] = Math.clamp(num(sys.skills[k], 15), 15, 95);
+    }
+  }
+
+  /** @override */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    const sys = this.system;
+
+    if (Number.isFinite(sys.hp?.max) && Number.isFinite(sys.hp?.value)) {
+      sys.hp.value = Math.clamp(sys.hp.value, 0, sys.hp.max);
+    }
+
+    if (Number.isFinite(sys.experience?.max) && Number.isFinite(sys.experience?.value)) {
+      sys.experience.value = Math.clamp(sys.experience.value, 0, sys.experience.max);
     }
   }
 }

--- a/module/effect-helpers.js
+++ b/module/effect-helpers.js
@@ -1,0 +1,126 @@
+// module/effect-helpers.js
+const DEFAULT_ICON = "icons/svg/aura.svg";
+
+function localize(label) {
+  if (!label) return "";
+  const i18n = game?.i18n;
+  if (label && typeof label === "string" && i18n?.has?.(label, { strict: false })) {
+    return i18n.localize(label);
+  }
+  return label;
+}
+
+function resolveModeLabel(mode) {
+  const config = CONFIG?.ActiveEffect ?? {};
+  const modes = config.modes ?? CONST?.ACTIVE_EFFECT_MODES ?? {};
+  for (const [key, value] of Object.entries(modes)) {
+    if (value !== mode) continue;
+    const labels = config.modeLabels ?? {};
+    const label = labels?.[key] ?? `EFFECT.MODE_${key}`;
+    const localized = localize(label);
+    return localized || key;
+  }
+  return String(mode);
+}
+
+function mapChange(change = {}) {
+  const key = String(change.key ?? "");
+  const value = change.value ?? "";
+  const mode = change.mode ?? CONST?.ACTIVE_EFFECT_MODES?.CUSTOM ?? 0;
+  return {
+    key,
+    value,
+    mode,
+    modeLabel: resolveModeLabel(mode)
+  };
+}
+
+function serializeEffect(effect) {
+  if (!effect) return null;
+  const durationLabel = typeof effect.duration?.label === "string"
+    ? effect.duration.label
+    : "";
+  const changes = Array.isArray(effect.changes)
+    ? effect.changes.map(mapChange)
+    : [];
+  return {
+    id: effect.id,
+    name: effect.name ?? "Efecto",
+    icon: effect.icon || DEFAULT_ICON,
+    disabled: !!effect.disabled,
+    isSuppressed: !!effect.isSuppressed,
+    origin: effect.origin ?? "",
+    durationLabel,
+    changes
+  };
+}
+
+export function mapActiveEffects(document) {
+  const collection = document?.effects;
+  if (!collection) return [];
+  return collection.contents.map(serializeEffect).filter((effect) => !!effect);
+}
+
+export const DEFAULT_EFFECT_ICON = DEFAULT_ICON;
+
+export function bindEffectControls(root, document, scope) {
+  const isElement = root instanceof HTMLElement || root instanceof DocumentFragment;
+  if (!isElement || !document) return;
+  const selector = typeof scope === "string"
+    ? `[data-effect-scope='${scope}']`
+    : "[data-effect-scope]";
+  const container = root.querySelector(selector);
+  if (!container) return;
+
+  const getEffectFrom = (element) => {
+    const effectId = element?.closest?.("[data-effect-id]")?.dataset?.effectId;
+    if (!effectId) return null;
+    return document.effects?.get?.(effectId) ?? null;
+  };
+
+  const createButton = container.querySelector("[data-action='create-effect']");
+  if (createButton) {
+    createButton.addEventListener("click", async (event) => {
+      event.preventDefault();
+      const i18n = game?.i18n;
+      const defaultName = i18n?.has?.("PMD.NewEffect", { strict: false })
+        ? i18n.localize("PMD.NewEffect")
+        : "Nuevo efecto";
+      const effectData = {
+        name: defaultName,
+        icon: DEFAULT_ICON,
+        origin: document.uuid ?? null,
+        disabled: false,
+        changes: []
+      };
+      const created = await document.createEmbeddedDocuments("ActiveEffect", [effectData]);
+      created?.[0]?.sheet?.render?.(true);
+    });
+  }
+
+  container.querySelectorAll("[data-action='edit-effect']").forEach((element) => {
+    element.addEventListener("click", (event) => {
+      event.preventDefault();
+      const effect = getEffectFrom(event.currentTarget ?? element);
+      effect?.sheet?.render?.(true);
+    });
+  });
+
+  container.querySelectorAll("[data-action='delete-effect']").forEach((element) => {
+    element.addEventListener("click", async (event) => {
+      event.preventDefault();
+      const effect = getEffectFrom(event.currentTarget ?? element);
+      if (!effect) return;
+      await effect.delete();
+    });
+  });
+
+  container.querySelectorAll("[data-action='toggle-effect']").forEach((element) => {
+    element.addEventListener("click", async (event) => {
+      event.preventDefault();
+      const effect = getEffectFrom(event.currentTarget ?? element);
+      if (!effect) return;
+      await effect.update({ disabled: !effect.disabled });
+    });
+  });
+}

--- a/module/init.js
+++ b/module/init.js
@@ -7,6 +7,10 @@ import { PMDItemSheet } from "./item-sheet.js";
 Hooks.once("init", function () {
   console.log("PMD-Explorers-of-Fate | Inicializando sistema básico");
 
+  loadTemplates([
+    "systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs"
+  ]);
+
   // Registrar clases de documento
   CONFIG.Actor.documentClass = MyActor;
 

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -1,5 +1,6 @@
 // module/item-sheet.js
 import { TYPE_OPTIONS } from "./pokemon-types.js";
+import { mapActiveEffects, bindEffectControls } from "./effect-helpers.js";
 const BaseItemSheet =
   foundry?.appv1?.sheets?.ItemSheet ??
   foundry?.applications?.sheets?.ItemSheet ??
@@ -26,6 +27,17 @@ function createItemSheetOptions() {
     submitOnChange: true,
     closeOnSubmit: false
   };
+}
+
+function resolveHTMLElement(html) {
+  if (!html) return null;
+  const element = html?.element ?? html;
+  if (element instanceof HTMLElement || element instanceof DocumentFragment) return element;
+  if (typeof element === "object" && element !== null && 0 in element) {
+    const candidate = element[0];
+    if (candidate instanceof HTMLElement || candidate instanceof DocumentFragment) return candidate;
+  }
+  return null;
 }
 
 export class PMDItemSheet extends BaseItemSheet {
@@ -85,6 +97,7 @@ export class PMDItemSheet extends BaseItemSheet {
     data.isTrait = this.item.type === "trait";
     data.itemType = this.item.type;
     data.typeOptions = TYPE_OPTIONS;
+    data.activeEffects = mapActiveEffects(this.item);
     return data;
   }
 
@@ -93,5 +106,11 @@ export class PMDItemSheet extends BaseItemSheet {
     if (typeof super.activateListeners === "function") {
       super.activateListeners(html);
     }
+
+    if (!this.isEditable) return;
+    const root = resolveHTMLElement(html);
+    if (!root) return;
+
+    bindEffectControls(root, this.item, "item");
   }
 }

--- a/module/item.js
+++ b/module/item.js
@@ -2,11 +2,10 @@
 import { normalizeTypeValue } from "./pokemon-types.js";
 export class PMDItem extends Item {
   /** @override */
-  prepareDerivedData() {
-    super.prepareDerivedData();
+  prepareBaseData() {
+    super.prepareBaseData();
     const sys = this.system;
 
-    // Saneo básico y clamps donde corresponda
     const num = (v, d = 0) => {
       const n = Number(v);
       return Number.isFinite(n) ? n : d;
@@ -15,19 +14,16 @@ export class PMDItem extends Item {
     switch (this.type) {
       case "move": {
         sys.pp ??= { max: 10, value: 10 };
-        sys.pp.max   = Math.max(0, num(sys.pp.max, 10));
-        sys.pp.value = Math.clamp(num(sys.pp.value, sys.pp.max), 0, sys.pp.max);
+        sys.pp.max = Math.max(0, num(sys.pp.max, 10));
+        sys.pp.value = num(sys.pp.value, sys.pp.max);
 
         sys.accuracy = num(sys.accuracy, 75);
-
         sys.baseDamage = Math.max(0, num(sys.baseDamage, 10));
 
-        // Normaliza category
         if (!["physical", "special", "status"].includes(sys.category)) {
           sys.category = "physical";
         }
 
-        // Strings seguros
         sys.range   = String(sys.range ?? "");
         sys.element = normalizeTypeValue(sys.element);
         sys.effect  = String(sys.effect ?? "");
@@ -54,8 +50,8 @@ export class PMDItem extends Item {
 
         if (this.type === "consumable") {
           sys.uses ??= { max: 1, value: 1 };
-          sys.uses.max   = Math.max(0, Math.round(num(sys.uses.max, 1)));
-          sys.uses.value = Math.clamp(Math.round(num(sys.uses.value, sys.uses.max)), 0, sys.uses.max);
+          sys.uses.max = Math.max(0, Math.round(num(sys.uses.max, 1)));
+          sys.uses.value = Math.round(num(sys.uses.value, sys.uses.max));
         }
         break;
       }
@@ -64,6 +60,24 @@ export class PMDItem extends Item {
         const str = (v) => String(v ?? "");
         sys.effect = str(sys.effect);
         break;
+      }
+    }
+  }
+
+  /** @override */
+  prepareDerivedData() {
+    super.prepareDerivedData();
+    const sys = this.system;
+
+    if (this.type === "move") {
+      if (Number.isFinite(sys.pp?.max) && Number.isFinite(sys.pp?.value)) {
+        sys.pp.value = Math.clamp(sys.pp.value, 0, sys.pp.max);
+      }
+    }
+
+    if (this.type === "consumable") {
+      if (Number.isFinite(sys.uses?.max) && Number.isFinite(sys.uses?.value)) {
+        sys.uses.value = Math.clamp(sys.uses.value, 0, sys.uses.max);
       }
     }
   }

--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -129,3 +129,85 @@
   color: var(--color-text-dark-5);
   font-style: italic;
 }
+
+/* === Pestaña de efectos activos === */
+.PMD-Explorers-of-Fate .effects-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effects-header {
+  align-items: center;
+  gap: 8px;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effects-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effects-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effects-list .effect {
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.2));
+  border-radius: 4px;
+  padding: 6px;
+  background: var(--color-bg-alt, rgba(0, 0, 0, 0.03));
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effects-list .effect.is-disabled {
+  opacity: 0.7;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effects-list .effect.is-suppressed {
+  border-style: dashed;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effect-icon img {
+  display: block;
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effect-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effect-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effect-tag {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 8px;
+  background: var(--color-border, rgba(0, 0, 0, 0.1));
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effect-controls {
+  gap: 4px;
+}
+
+.PMD-Explorers-of-Fate .effects-panel .effect-controls .effect-control {
+  font-size: 0.75rem;
+}

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -63,6 +63,7 @@
     <a class="item" data-tab="moves">Movimientos</a>
     <a class="item" data-tab="traits">Rasgos</a>
     <a class="item" data-tab="inventory">Objetos</a>
+    <a class="item" data-tab="effects">Efectos</a>
   </nav>
 
   <section class="sheet-body">
@@ -374,6 +375,10 @@
       {{/if}}
     </div>
   {{/each}}
-</div>
+    </div>
+
+    <div class="tab" data-tab="effects" data-group="primary">
+      {{> systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs effects=activeEffects scope="actor" editable=editable}}
+    </div>
   </section>
 </form>

--- a/templates/item-move-sheet.hbs
+++ b/templates/item-move-sheet.hbs
@@ -9,6 +9,7 @@
   <nav class="sheet-tabs tabs" data-group="primary">
     <a class="item" data-tab="details">Detalles</a>
     <a class="item" data-tab="text">Texto</a>
+    <a class="item" data-tab="effects">Efectos</a>
   </nav>
 
   <section class="sheet-body">
@@ -60,6 +61,10 @@
         <label>Efecto (opcional)</label>
         <textarea name="system.effect" rows="6">{{system.effect}}</textarea>
       </div>
+    </div>
+
+    <div class="tab" data-tab="effects" data-group="primary">
+      {{> systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs effects=activeEffects scope="item" editable=editable}}
     </div>
   </section>
 </form>

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -9,6 +9,7 @@
   <nav class="sheet-tabs tabs" data-group="primary">
     <a class="item" data-tab="details">Detalles</a>
     <a class="item" data-tab="description">Descripción</a>
+    <a class="item" data-tab="effects">Efectos</a>
   </nav>
 
   <section class="sheet-body">
@@ -57,6 +58,10 @@
           <textarea name="system.effect" rows="5">{{system.effect}}</textarea>
         </div>
       {{/if}}
+    </div>
+
+    <div class="tab" data-tab="effects" data-group="primary">
+      {{> systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs effects=activeEffects scope="item" editable=editable}}
     </div>
   </section>
 </form>

--- a/templates/parts/active-effects.hbs
+++ b/templates/parts/active-effects.hbs
@@ -1,0 +1,54 @@
+<section class="effects-panel" data-effect-scope="{{scope}}">
+  <header class="effects-header flexrow">
+    <h3 class="effects-title">Efectos activos</h3>
+    {{#if editable}}
+      <button type="button" data-action="create-effect">+ Nuevo efecto</button>
+    {{/if}}
+  </header>
+
+  {{#if effects.length}}
+    <ol class="effects-list">
+      {{#each effects}}
+        <li class="effect flexrow{{#if disabled}} is-disabled{{/if}}{{#if isSuppressed}} is-suppressed{{/if}}" data-effect-id="{{id}}">
+          <div class="effect-icon">
+            <img src="{{icon}}" alt="{{name}}" width="32" height="32" loading="lazy" />
+          </div>
+          <div class="effect-details">
+            <div class="effect-title-row">
+              <strong>{{name}}</strong>
+              {{#if disabled}}
+                <span class="effect-tag">Desactivado</span>
+              {{/if}}
+              {{#if isSuppressed}}
+                <span class="effect-tag">Anulado</span>
+              {{/if}}
+            </div>
+            {{#if durationLabel}}
+              <div class="effect-duration small">Duración: {{durationLabel}}</div>
+            {{/if}}
+            {{#if changes.length}}
+              <ul class="effect-changes small">
+                {{#each changes}}
+                  <li><code>{{key}}</code> {{modeLabel}} → <strong>{{value}}</strong></li>
+                {{/each}}
+              </ul>
+            {{else}}
+              <p class="notes small">Sin cambios definidos.</p>
+            {{/if}}
+          </div>
+          {{#if ../editable}}
+            <div class="effect-controls flexcol">
+              <button type="button" class="effect-control" data-action="toggle-effect">
+                {{#if disabled}}Activar{{else}}Desactivar{{/if}}
+              </button>
+              <button type="button" class="effect-control" data-action="edit-effect">Editar</button>
+              <button type="button" class="effect-control" data-action="delete-effect">Eliminar</button>
+            </div>
+          {{/if}}
+        </li>
+      {{/each}}
+    </ol>
+  {{else}}
+    <p class="notes">No hay efectos activos.</p>
+  {{/if}}
+</section>


### PR DESCRIPTION
## Summary
- integrate Active Effect data handling in actor and item documents so modifiers persist with base stats
- add reusable helpers and UI sections to manage effects on actor and item sheets
- preload new Active Effect partial and style the effects tab for both sheets

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9a544eca0832b83e6ade1bad2fa97