### PR TITLE
Aplicar efectos solo al equipar o consumir objetos

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -632,14 +632,54 @@ export class MyActorSheet extends BaseActorSheet {
     }
 
     const newQuantity = Math.max(0, quantity - 1);
+    const itemUuid = item.uuid ?? null;
     const effectText = this._formatText(item.system?.effect ?? "");
     const itemName = foundry.utils.escapeHTML(item.name ?? "Objeto");
     const actorName = foundry.utils.escapeHTML(this.actor.name ?? "Personaje");
+
+    const effectsToCreate = (item.effects?.contents ?? [])
+      .filter((effect) => effect?.transfer !== false)
+      .map((effect) => {
+        const data = typeof effect.toObject === "function" ? effect.toObject() : effect;
+        if (!data) return null;
+        let clone;
+        if (foundry?.utils?.duplicate) {
+          clone = foundry.utils.duplicate(data);
+        } else if (typeof structuredClone === "function") {
+          clone = structuredClone(data);
+        } else {
+          try {
+            clone = JSON.parse(JSON.stringify(data));
+          } catch (err) {
+            clone = { ...data };
+          }
+        }
+        if (!clone) return null;
+        delete clone._id;
+        clone.origin = clone.origin || itemUuid;
+        clone.transfer = false;
+        clone.disabled = false;
+        if (clone.duration) {
+          delete clone.duration.startTime;
+          delete clone.duration.startRound;
+          delete clone.duration.startTurn;
+          delete clone.duration.combat;
+        }
+        if (!clone.name && item.name) {
+          clone.name = item.name;
+        }
+        return clone;
+      })
+      .filter((data) => data !== null);
 
     if (newQuantity > 0) {
       await item.update({ "system.quantity": newQuantity });
     } else {
       await this.actor.deleteEmbeddedDocuments("Item", [item.id]);
+    }
+
+    if (effectsToCreate.length) {
+      await this.actor.createEmbeddedDocuments("ActiveEffect", effectsToCreate);
     }
 
     const parts = [`<div><strong>${actorName}</strong> consumió ${itemName}.</div>`];

--- a/module/item.js
+++ b/module/item.js
@@ -81,4 +81,19 @@ export class PMDItem extends Item {
       }
     }
   }
+
+  /** @override */
+  applyActiveEffects(actor, changeData) {
+    if (this.type === "equipment" && !this.system?.equipped) {
+      return;
+    }
+
+    if (this.type === "consumable") {
+      return;
+    }
+
+    if (typeof super.applyActiveEffects === "function") {
+      return super.applyActiveEffects(actor, changeData);
+    }
+  }
 }


### PR DESCRIPTION
## Resumen
- Evitar que los efectos de equipamiento transfieran bonificaciones cuando el objeto no está marcado como equipado.
- Generar efectos activos en el actor únicamente al consumir objetos con efectos transferibles.

## Pruebas
- No se ejecutaron pruebas; no aplica.


------
https://chatgpt.com/codex/tasks/task_e_68d9ad596f10832b84d3a4557d144d00