### PR TITLE
Fix consumable permanent heal stacking

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -660,7 +660,8 @@ export class MyActorSheet extends BaseActorSheet {
             .reduce((value, part) => (value && typeof value === "object" ? value[part] : undefined), object);
         });
 
-      const baseValueRaw = getProperty(this.actor, attributeConfig.path);
+      const actorSource = this.actor?._source ?? {};
+      const baseValueRaw = getProperty(actorSource, attributeConfig.path);
       const baseValue = Number(baseValueRaw);
       const safeBase = Number.isFinite(baseValue) ? baseValue : 0;
       const magnitude = Math.abs(effectAmount);

--- a/module/consumable-effects.js
+++ b/module/consumable-effects.js
@@ -38,7 +38,8 @@ export const CONSUMABLE_PERMANENT_ATTRIBUTE_CONFIG = {
     path: "system.hp.max",
     clamp: clampHpMax,
     afterUpdate: (newMax, actor) => {
-      const currentHp = Number(actor?.system?.hp?.value);
+      const sourceHp = actor?._source?.system?.hp?.value;
+      const currentHp = Number(sourceHp ?? actor?.system?.hp?.value);
       if (!Number.isFinite(currentHp)) return null;
       const safeMax = Number.isFinite(newMax) ? Math.max(0, Math.round(newMax)) : 0;
       const clamped = Math.clamp(Math.round(currentHp), 0, safeMax);


### PR DESCRIPTION
## Summary
- evitar que las curaciones permanentes multipliquen su valor al leer los datos base del actor al consumir un objeto
- ajustar el postproceso de HP máximo para que utilice el valor base del actor al recalcular HP

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9baad5688832b8a0c809253a79342