### PR TITLE
Improve active effect editing and add accuracy bonus stat

### DIFF
--- a/module/active-effect-ui.js
+++ b/module/active-effect-ui.js
@@ -1,0 +1,96 @@
+// module/active-effect-ui.js
+import { ACTIVE_EFFECT_ATTRIBUTE_OPTIONS } from "./consumable-effects.js";
+
+const KEY_INPUT_SELECTOR = "input[name][name$='.key']";
+const SELECT_CLASS = "pmd-effect-attribute-select";
+
+function findRootElement(html) {
+  if (!html) return null;
+  const element = html?.element ?? html;
+  if (element instanceof HTMLElement || element instanceof DocumentFragment) return element;
+  if (typeof element === "object" && element !== null && 0 in element) {
+    const candidate = element[0];
+    if (candidate instanceof HTMLElement || candidate instanceof DocumentFragment) return candidate;
+  }
+  return null;
+}
+
+function syncSelectWithInput(select, input) {
+  if (!select || !input) return;
+  const match = ACTIVE_EFFECT_ATTRIBUTE_OPTIONS.find((option) => option.value === input.value);
+  select.value = match ? match.value : "";
+}
+
+function createAttributeSelect(input) {
+  if (!(input instanceof HTMLInputElement)) return null;
+  if (input.dataset.pmdHasAttributeSelect === "true") return input.previousElementSibling;
+
+  const select = document.createElement("select");
+  select.classList.add(SELECT_CLASS);
+
+  for (const option of ACTIVE_EFFECT_ATTRIBUTE_OPTIONS) {
+    const opt = document.createElement("option");
+    opt.value = option.value;
+    opt.textContent = option.label;
+    select.appendChild(opt);
+  }
+
+  syncSelectWithInput(select, input);
+
+  select.addEventListener("change", () => {
+    if (!input) return;
+    if (select.value) {
+      input.value = select.value;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    } else {
+      input.focus();
+    }
+  });
+
+  input.addEventListener("input", () => {
+    syncSelectWithInput(select, input);
+  });
+
+  input.insertAdjacentElement("beforebegin", select);
+  input.dataset.pmdHasAttributeSelect = "true";
+  return select;
+}
+
+function applyAttributeSelects(root) {
+  if (!root) return;
+  root.querySelectorAll(KEY_INPUT_SELECTOR).forEach((input) => {
+    createAttributeSelect(input);
+  });
+}
+
+function observeChanges(sheet, root) {
+  if (!root || !sheet) return;
+  if (sheet._pmdEffectObserver) {
+    sheet._pmdEffectObserver.disconnect();
+  }
+
+  const observer = new MutationObserver(() => {
+    applyAttributeSelects(root);
+  });
+
+  observer.observe(root, { childList: true, subtree: true });
+  sheet._pmdEffectObserver = observer;
+}
+
+export function setupActiveEffectUI() {
+  Hooks.on("renderActiveEffectConfig", (sheet, html) => {
+    const element = findRootElement(html);
+    if (!element) return;
+    applyAttributeSelects(element);
+    observeChanges(sheet, element);
+  });
+
+  Hooks.on("closeActiveEffectConfig", (sheet) => {
+    const observer = sheet?._pmdEffectObserver;
+    observer?.disconnect?.();
+    if (sheet) {
+      delete sheet._pmdEffectObserver;
+    }
+  });
+}

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -523,7 +523,8 @@ export class MyActorSheet extends BaseActorSheet {
     const accBonus = await this._promptAttackBonus(item.name ?? "Ataque");
     if (accBonus === null) return;
     const baseAcc = Number(item.system?.accuracy ?? 0);
-    const finalThreshold = baseAcc + accBonus;
+    const globalAccBonus = Number(this.actor.system?.accuracyBonus ?? 0);
+    const finalThreshold = baseAcc + accBonus + globalAccBonus;
 
     // Tirada d100
     const roll = await (new Roll("1d100")).evaluate({ async: true });
@@ -608,7 +609,16 @@ export class MyActorSheet extends BaseActorSheet {
       <div><strong>Usa Movimiento:</strong> ${foundry.utils.escapeHTML(item.name)}</div>
       <div><small>${elem ? `Tipo: ${elem} · ` : ""}${cat ? `Categoría: ${cat}` : ""}${rng ? ` · Rango: ${rng}` : ""}</small></div>
       <hr/>
-      <div>Precisión base: <b>${baseAcc}</b> ${accBonus ? `(bono ${accBonus > 0 ? "+" : ""}${accBonus})` : ""}</div>
+      <div>Precisión base: <b>${baseAcc}</b> ${(() => {
+        const parts = [];
+        if (globalAccBonus) {
+          parts.push(`bono global ${globalAccBonus > 0 ? "+" : ""}${globalAccBonus}`);
+        }
+        if (accBonus) {
+          parts.push(`bono situacional ${accBonus > 0 ? "+" : ""}${accBonus}`);
+        }
+        return parts.length ? `(${parts.join(' · ')})` : "";
+      })()}</div>
       <div>Umbral final: <b>${finalThreshold}</b></div>
       <div>d100: <b>${raw}</b></div>
       <div>Chequeo: ${isHit ? '<span class="roll-success">ACIERTO</span>' : '<span class="roll-failure">FALLO</span>'} ${isCrit ? '· <b>CRÍTICO</b>' : ''}</div>

--- a/module/actor.js
+++ b/module/actor.js
@@ -19,6 +19,7 @@ export class MyActor extends Actor {
     sys.speed       = num(sys.speed, 0);
     sys.stab        = num(sys.stab, 0);
     sys.basicattack = num(sys.basicattack, 0);
+    sys.accuracyBonus = num(sys.accuracyBonus, 0);
     sys.belly       = num(sys.belly, 100);
     sys.lp          = num(sys.lp, 0);
 

--- a/module/consumable-effects.js
+++ b/module/consumable-effects.js
@@ -82,12 +82,25 @@ export const CONSUMABLE_PERMANENT_ATTRIBUTE_CONFIG = {
     path: "system.spDefense",
     clamp: clampInteger,
   },
+  accuracyBonus: {
+    label: "Precisión global",
+    path: "system.accuracyBonus",
+    clamp: clampInteger,
+  },
 };
 
 export const CONSUMABLE_PERMANENT_ATTRIBUTE_OPTIONS = [
   { key: "", label: "Sin efecto permanente" },
   ...Object.entries(CONSUMABLE_PERMANENT_ATTRIBUTE_CONFIG).map(([key, config]) => ({
     key,
+    label: config.label,
+  })),
+];
+
+export const ACTIVE_EFFECT_ATTRIBUTE_OPTIONS = [
+  { value: "", label: "Selecciona atributo…" },
+  ...Object.values(CONSUMABLE_PERMANENT_ATTRIBUTE_CONFIG).map((config) => ({
+    value: config.path,
     label: config.label,
   })),
 ];

--- a/module/init.js
+++ b/module/init.js
@@ -3,6 +3,7 @@ import { MyActor } from "./actor.js";
 import { MyActorSheet } from "./actor-sheet.js";
 import { PMDItem } from "./item.js";
 import { PMDItemSheet } from "./item-sheet.js";
+import { setupActiveEffectUI } from "./active-effect-ui.js";
 
 Hooks.once("init", function () {
   console.log("PMD-Explorers-of-Fate | Inicializando sistema básico");
@@ -10,6 +11,8 @@ Hooks.once("init", function () {
   loadTemplates([
     "systems/PMD-Explorers-of-Fate/templates/parts/active-effects.hbs"
   ]);
+
+  setupActiveEffectUI();
 
   // Registrar clases de documento
   CONFIG.Actor.documentClass = MyActor;

--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -211,3 +211,8 @@
 .PMD-Explorers-of-Fate .effects-panel .effect-controls .effect-control {
   font-size: 0.75rem;
 }
+
+.pmd-effect-attribute-select {
+  width: 100%;
+  margin-bottom: 4px;
+}

--- a/template.json
+++ b/template.json
@@ -13,6 +13,7 @@
         "speed": 0,
         "stab": 0,
         "basicattack": 0,
+        "accuracyBonus": 0,
         "lp": 0,
         "belly": 100,
         "pasiva": "",

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -120,6 +120,11 @@
         </div>
 
         <div class="stat">
+          <label>Precisión Global</label>
+          <input type="number" name="system.accuracyBonus" value="{{system.accuracyBonus}}" data-dtype="Number"/>
+        </div>
+
+        <div class="stat">
           <label>LP</label>
           <input type="number" name="system.lp" value="{{system.lp}}" data-dtype="Number"/>
         </div>


### PR DESCRIPTION
## Summary
- add a global accuracy bonus attribute to actors, including sheet controls and default data
- incorporate the accuracy bonus into move rolls and consumable/effect configuration options
- enhance the active effect editor with an attribute selector and supporting styles

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9c451a8b8832b975b01145fd3aa0a