### PR TITLE
Desactivar efectos temporales de movimientos hasta su uso

### DIFF
--- a/module/effect-helpers.js
+++ b/module/effect-helpers.js
@@ -86,11 +86,12 @@ export function bindEffectControls(root, document, scope) {
       const defaultName = i18n?.has?.("PMD.NewEffect", { strict: false })
         ? i18n.localize("PMD.NewEffect")
         : "Nuevo efecto";
+      const isMove = document?.type === "move";
       const effectData = {
         name: defaultName,
         icon: DEFAULT_ICON,
         origin: document.uuid ?? null,
-        disabled: false,
+        disabled: isMove,
         changes: []
       };
       const created = await document.createEmbeddedDocuments("ActiveEffect", [effectData]);

--- a/module/item.js
+++ b/module/item.js
@@ -111,6 +111,14 @@ export class PMDItem extends Item {
         effect.disabled = baseDisabled || !isEquipped;
         effect.transfer = baseTransfer && isEquipped;
       }
+    } else if (this.type === "move") {
+      for (const effect of effects) {
+        if (!effect) continue;
+        const source = effect._source ?? {};
+        const baseDisabled = source.disabled !== false;
+        effect.disabled = baseDisabled;
+        effect.transfer = false;
+      }
     } else if (this.type === "consumable") {
       for (const effect of effects) {
         if (!effect) continue;


### PR DESCRIPTION
## Summary
- leave move active effects disabled by default and non-transferable so they only apply when triggered
- create new move effects already disabled to preserve the default state

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9cbe93bcc832b8b022bcb9df6dca5