### PR TITLE
Desactiva efectos temporales de movimientos hasta su uso

### DIFF
--- a/module/item.js
+++ b/module/item.js
@@ -111,7 +111,7 @@ export class PMDItem extends Item {
         effect.disabled = baseDisabled || !isEquipped;
         effect.transfer = baseTransfer && isEquipped;
       }
-    } else if (this.type === "consumable") {
+    } else if (this.type === "consumable" || this.type === "move") {
       for (const effect of effects) {
         if (!effect) continue;
         effect.disabled = true;


### PR DESCRIPTION
## Summary
- alinear la configuración de efectos temporales de los movimientos con la de los consumibles, manteniéndolos desactivados y sin transferencia por defecto

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9cebadb14832b81144bc2df2acb6f