### PR TITLE
Add damage application controls to attack chat messages

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -561,6 +561,7 @@ export class MyActorSheet extends BaseActorSheet {
     const canCalc = !!target && isHit && cat !== "status";
 
     let dmgBreakdownHTML = "";
+    let finalDamageValue = null;
 
     if (canCalc) {
       const hasStab = this._moveHasStab(elem);
@@ -594,12 +595,27 @@ export class MyActorSheet extends BaseActorSheet {
         }
 
         const finalDamage = isImmune ? 0 : Math.max(1, Math.ceil(dmg));
+        finalDamageValue = finalDamage;
         const defLine = isImmune
           ? `<div>− ${defKey}: <em>No aplica</em></div>`
           : `<div>− ${defKey}: <b>${defStat}</b></div>`;
         const finalNote = isImmune
           ? "<small>(objetivo inmune)</small>"
           : "<small>(redondeo ↑, mínimo 1)</small>";
+
+        const targetUuid = target?.uuid ?? "";
+        const safeTargetUuid = targetUuid ? foundry.utils.escapeHTML(targetUuid) : "";
+        const safeTargetName = foundry.utils.escapeHTML(target?.name ?? "Objetivo");
+
+        const applyButtonHtml = finalDamageValue !== null && safeTargetUuid
+          ? `
+          <div class="pmd-damage-actions">
+            <button type="button" data-action="apply-move-damage" data-damage="${finalDamageValue}" data-target-uuid="${safeTargetUuid}">
+              Aplicar ${finalDamageValue} de daño a ${safeTargetName}
+            </button>
+          </div>
+        `
+          : "";
 
         dmgBreakdownHTML = `
           <hr/>
@@ -614,6 +630,7 @@ export class MyActorSheet extends BaseActorSheet {
           <div>Enemigo: ${opts.enemy.op} ${opts.enemy.val}</div>
           ${defLine}
           <div><b>Daño final: ${finalDamage}</b> ${finalNote}</div>
+          ${applyButtonHtml}
         `;
       }
     }


### PR DESCRIPTION
## Summary
- add a button to move chat messages to apply calculated damage to the targeted creature
- handle chat button clicks to update HP and announce when the target is defeated

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd4c3151d0832ba81d26272b1c0bce