### PR TITLE
Añadir pestaña privada de trampa para objetos

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -786,7 +786,13 @@ export class MyActorSheet extends BaseActorSheet {
 
     const newQuantity = Math.max(0, quantity - 1);
     const itemUuid = item.uuid ?? null;
-    const effectText = this._formatText(item.system?.effect ?? "");
+    const trapData =
+      typeof item.system?.trap === "object" && !Array.isArray(item.system?.trap) ? item.system.trap : {};
+    const trapEnabled = trapData?.enabled === true;
+    const trapDescription = trapEnabled ? this._formatText(trapData?.description ?? "") : "";
+    const effectText = trapEnabled && trapDescription
+      ? trapDescription
+      : this._formatText(item.system?.effect ?? "");
     const itemName = foundry.utils.escapeHTML(item.name ?? "Objeto");
     const actorName = foundry.utils.escapeHTML(this.actor.name ?? "Personaje");
 
@@ -917,7 +923,13 @@ export class MyActorSheet extends BaseActorSheet {
   }
 
   async _useGearItem(item) {
-    const description = this._formatText(item.system?.description ?? "");
+    const trapData =
+      typeof item.system?.trap === "object" && !Array.isArray(item.system?.trap) ? item.system.trap : {};
+    const trapEnabled = trapData?.enabled === true;
+    const trapDescription = trapEnabled ? this._formatText(trapData?.description ?? "") : "";
+    const description = trapEnabled && trapDescription
+      ? trapDescription
+      : this._formatText(item.system?.description ?? "");
     const itemName = foundry.utils.escapeHTML(item.name ?? "Objeto");
     const actorName = foundry.utils.escapeHTML(this.actor.name ?? "Personaje");
 

--- a/module/item-sheet.js
+++ b/module/item-sheet.js
@@ -97,6 +97,7 @@ export class PMDItemSheet extends BaseItemSheet {
     data.isConsumable = this.item.type === "consumable";
     data.isGear = this.item.type === "gear";
     data.isTrait = this.item.type === "trait";
+    data.isGM = game?.user?.isGM ?? false;
     data.itemType = this.item.type;
     data.typeOptions = TYPE_OPTIONS;
     data.activeEffects = mapActiveEffects(this.item);

--- a/module/item.js
+++ b/module/item.js
@@ -16,6 +16,17 @@ export class PMDItem extends Item {
     super.prepareBaseData();
     const sys = this.system;
 
+    const trapData =
+      typeof sys.trap === "object" && sys.trap !== null && !Array.isArray(sys.trap)
+        ? sys.trap
+        : {};
+    const trapEnabled = trapData.enabled === true;
+    const trapDescription = String(trapData.description ?? "");
+    sys.trap = {
+      enabled: trapEnabled,
+      description: trapDescription,
+    };
+
     const num = (v, d = 0) => {
       const n = Number(v);
       return Number.isFinite(n) ? n : d;

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -12,6 +12,9 @@
     {{#if isConsumable}}
       <a class="item" data-tab="permanent">Efecto permanente</a>
     {{/if}}
+    {{#if isGM}}
+      <a class="item" data-tab="gm">Privado</a>
+    {{/if}}
     <a class="item" data-tab="effects">Efectos</a>
   </nav>
 
@@ -62,6 +65,35 @@
         </div>
       {{/if}}
     </div>
+
+    {{#if isGM}}
+      <div class="tab" data-tab="gm" data-group="primary">
+        <div class="field">
+          <label>¿Es trampa?</label>
+          <input
+            type="checkbox"
+            name="system.trap.enabled"
+            {{checked system.trap.enabled}}
+            data-toggle-target=".trap-details"
+          />
+        </div>
+
+        <div
+          class="field trap-details"
+          style="{{#unless system.trap.enabled}}display: none;{{/unless}}"
+        >
+          <label>Descripción oculta</label>
+          <textarea name="system.trap.description" rows="5">{{system.trap.description}}</textarea>
+        </div>
+
+        <p
+          class="notes trap-details"
+          style="{{#unless system.trap.enabled}}display: none;{{/unless}}"
+        >
+          Esta descripción reemplazará a la normal al usarse el objeto.
+        </p>
+      </div>
+    {{/if}}
 
     {{#if isConsumable}}
       <div class="tab" data-tab="permanent" data-group="primary">


### PR DESCRIPTION
## Resumen
- agregar una pestaña Privado visible solo para el GM en la hoja de objetos con la opción de marcar un ítem como trampa y definir su descripción oculta
- normalizar los datos de trampa en los ítems y mostrar la descripción oculta cuando se activa el objeto en el chat

## Pruebas
- No se añadieron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd923173d4832b84f2ff31a3138090