### PR TITLE
Enable rolling a default basic attack

### DIFF
--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -118,7 +118,10 @@
         </div>
         <div class="stat">
           <label>Basic Attack</label>
-          <input type="number" name="system.basicattack" value="{{system.basicattack}}" data-dtype="Number"/>
+          <div class="basic-attack-controls" style="display:flex; gap:6px; align-items:center;">
+            <input type="number" name="system.basicattack" value="{{system.basicattack}}" data-dtype="Number"/>
+            <button type="button" class="as-link" data-action="use-basic-attack">Atacar</button>
+          </div>
         </div>
 
         <div class="stat">


### PR DESCRIPTION
## Summary
- add a quick action button next to the Basic Attack stat to roll the default attack
- implement the default attack roll logic with fixed accuracy, damage calculation, and chat output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb463023c832bb5b0b5ff3594dac3