### PR TITLE
Permitir múltiples efectos permanentes en consumibles

### DIFF
--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -55,6 +55,28 @@
   box-sizing: border-box;
 }
 
+.PMD-Explorers-of-Fate.sheet.item .permanent-effects-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.PMD-Explorers-of-Fate.sheet.item .permanent-effects-header button {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 999px;
+  font-weight: bold;
+  line-height: 1;
+}
+
+.PMD-Explorers-of-Fate.sheet.item .permanent-effects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 /* === Botón que se ve como enlace === */
 .PMD-Explorers-of-Fate .as-link {
   background: none;

--- a/template.json
+++ b/template.json
@@ -76,6 +76,7 @@
     "consumable": {
       "templates": ["baseObject"],
       "uses": { "max": 1, "value": 1 },
+      "permanentEffects": [{ "attribute": "", "mode": "add", "amount": 0 }],
       "permanentEffect": { "attribute": "", "mode": "add", "amount": 0 }
     },
     "gear": {

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -97,36 +97,45 @@
 
     {{#if isConsumable}}
       <div class="tab" data-tab="permanent" data-group="primary">
-        <div class="grid two-col">
-          <div class="field">
-            <label>Atributo</label>
-            <select name="system.permanentEffect.attribute">
-              {{#each consumablePermanentAttributes as |option|}}
-                <option value="{{option.key}}" {{#if (eq option.key ../system.permanentEffect.attribute)}}selected{{/if}}>
-                  {{option.label}}
-                </option>
-              {{/each}}
-            </select>
-          </div>
+        <div class="field permanent-effects-header">
+          <label>Efectos permanentes</label>
+          <button type="button" class="permanent-effect-add" title="Añadir efecto permanente" aria-label="Añadir efecto permanente">+</button>
+        </div>
 
-          <div class="field">
-            <label>Modo</label>
-            <select name="system.permanentEffect.mode">
-              <option value="add" {{#if (eq system.permanentEffect.mode "add")}}selected{{/if}}>Sumar</option>
-              <option value="subtract" {{#if (eq system.permanentEffect.mode "subtract")}}selected{{/if}}>Restar</option>
-            </select>
-          </div>
+        <div class="permanent-effects-list">
+          {{#each permanentEffects as |effect|}}
+            <div class="grid two-col permanent-effect-row">
+              <div class="field">
+                <label>Atributo</label>
+                <select name="system.permanentEffects.{{@index}}.attribute">
+                  {{#each ../consumablePermanentAttributes as |option|}}
+                    <option value="{{option.key}}" {{#if (eq option.key effect.attribute)}}selected{{/if}}>
+                      {{option.label}}
+                    </option>
+                  {{/each}}
+                </select>
+              </div>
 
-          <div class="field">
-            <label>Cantidad</label>
-            <input
-              type="number"
-              name="system.permanentEffect.amount"
-              value="{{system.permanentEffect.amount}}"
-              data-dtype="Number"
-              min="0"
-            />
-          </div>
+              <div class="field">
+                <label>Modo</label>
+                <select name="system.permanentEffects.{{@index}}.mode">
+                  <option value="add" {{#if (eq effect.mode "add")}}selected{{/if}}>Sumar</option>
+                  <option value="subtract" {{#if (eq effect.mode "subtract")}}selected{{/if}}>Restar</option>
+                </select>
+              </div>
+
+              <div class="field">
+                <label>Cantidad</label>
+                <input
+                  type="number"
+                  name="system.permanentEffects.{{@index}}.amount"
+                  value="{{effect.amount}}"
+                  data-dtype="Number"
+                  min="0"
+                />
+              </div>
+            </div>
+          {{/each}}
         </div>
 
         <p class="notes">Este cambio se aplicará cuando se utilice el consumible.</p>


### PR DESCRIPTION
## Summary
- permite añadir varias filas de efectos permanentes desde la hoja del objeto consumible
- normaliza los datos de efectos permanentes como listas manteniendo compatibilidad con el formato anterior
- aplica todos los efectos al consumir el objeto y ajusta el estilo del nuevo control

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e14eec27f8832ba3a2a6d58cde6235