### PR TITLE
Permitir eliminar efectos permanentes y ajustar daño del ataque básico

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -545,31 +545,22 @@ export class MyActorSheet extends BaseActorSheet {
     const isHit = raw < finalThreshold;
 
     const baseDamageRaw = Number(this.actor.system?.basicattack ?? 0);
-    const attackStatRaw = Number(this.actor.system?.attack ?? 0);
-    const defenseStatRaw = targetActor ? Number(targetActor.system?.defense ?? 0) : 0;
-
     const baseDamage = Number.isFinite(baseDamageRaw) ? baseDamageRaw : 0;
-    const attackStat = Number.isFinite(attackStatRaw) ? attackStatRaw : 0;
-    const defenseStat = Number.isFinite(defenseStatRaw) ? defenseStatRaw : 0;
 
     let dmgBreakdownHTML = "";
     let finalDamageValue = null;
 
     if (isHit && targetActor) {
-      const basePlusAttack = baseDamage + attackStat;
-      let damage = basePlusAttack;
+      let damage = baseDamage;
       if (isCrit) damage *= 1.5;
-      damage -= defenseStat;
       const finalDamage = Math.max(1, Math.ceil(damage));
       finalDamageValue = finalDamage;
-      const defLine = `<div>− Def: <b>${defenseStat}</b></div>`;
       const finalNote = "<small>(redondeo ↑, mínimo 1)</small>";
       dmgBreakdownHTML = `
         <hr/>
         <div><b>Cálculo de Daño</b></div>
-        <div>Base (${baseDamage}) + Atk: <b>${basePlusAttack}</b></div>
+        <div>Daño base: <b>${baseDamage}</b></div>
         <div>Crítico: ${isCrit ? "Sí (×1.5)" : "No"}</div>
-        ${defLine}
         <div><b>Daño final: ${finalDamage}</b> ${finalNote}</div>
       `;
     }

--- a/styles/sheet.css
+++ b/styles/sheet.css
@@ -69,6 +69,32 @@
   border-radius: 999px;
   font-weight: bold;
   line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.PMD-Explorers-of-Fate.sheet.item .permanent-effect-row {
+  grid-template-columns: repeat(3, 1fr) auto;
+  align-items: end;
+}
+
+.PMD-Explorers-of-Fate.sheet.item .permanent-effect-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.PMD-Explorers-of-Fate.sheet.item .permanent-effect-remove {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 999px;
+  font-weight: bold;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .PMD-Explorers-of-Fate.sheet.item .permanent-effects-list {

--- a/templates/item-object-sheet.hbs
+++ b/templates/item-object-sheet.hbs
@@ -134,6 +134,18 @@
                   min="0"
                 />
               </div>
+
+              <div class="permanent-effect-actions">
+                <button
+                  type="button"
+                  class="permanent-effect-remove"
+                  data-index="{{@index}}"
+                  title="Eliminar efecto permanente"
+                  aria-label="Eliminar efecto permanente"
+                >
+                  −
+                </button>
+              </div>
             </div>
           {{/each}}
         </div>


### PR DESCRIPTION
## Summary
- añade controles en la hoja de objeto para poder eliminar efectos permanentes y actualiza el estilo correspondiente
- reutiliza la sanitización de efectos al agregar o quitar filas para mantener la compatibilidad con datos heredados
- modifica el cálculo del ataque básico para que solo use el daño base (con multiplicador de crítico) sin aplicar Ataque ni Defensa

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5327f8f58832b8f611dd9a986be09