### PR TITLE
Add temporary HP attribute and expand effect attribute options

### DIFF
--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -282,6 +282,10 @@ export class MyActorSheet extends BaseActorSheet {
     if (Number.isFinite(maxHP)) {
       actorUpdates["system.hp.value"] = Math.max(0, maxHP);
     }
+    const tempHP = Number(this.actor.system?.hp?.temp);
+    if (Number.isFinite(tempHP) && tempHP !== 0) {
+      actorUpdates["system.hp.temp"] = 0;
+    }
 
     const moveUpdates = this.actor.items
       .filter((item) => item.type === "move")

--- a/module/actor.js
+++ b/module/actor.js
@@ -32,9 +32,10 @@ export class MyActor extends Actor {
     sys.leyenda = String(sys.leyenda ?? "");
     sys.background = String(sys.background ?? "");
 
-    sys.hp ??= { max: 10, value: 10 };
+    sys.hp ??= { max: 10, value: 10, temp: 0 };
     sys.hp.max = num(sys.hp.max, 10);
     sys.hp.value = num(sys.hp.value, sys.hp.max);
+    sys.hp.temp = Math.max(0, Math.round(num(sys.hp.temp, 0)));
 
     const level = num(sys.lvl, 1);
     sys.experience ??= { max: level * 100, value: 0 };
@@ -59,6 +60,10 @@ export class MyActor extends Actor {
 
     if (Number.isFinite(sys.hp?.max) && Number.isFinite(sys.hp?.value)) {
       sys.hp.value = Math.clamp(sys.hp.value, 0, sys.hp.max);
+    }
+
+    if (Number.isFinite(sys.hp?.temp)) {
+      sys.hp.temp = Math.max(0, Math.round(sys.hp.temp));
     }
 
     if (Number.isFinite(sys.experience?.max) && Number.isFinite(sys.experience?.value)) {

--- a/module/consumable-effects.js
+++ b/module/consumable-effects.js
@@ -27,6 +27,14 @@ const clampHpMax = (value) => {
   return Math.max(0, Math.round(value));
 };
 
+const clampExperienceValue = (value, actor) => {
+  const maxExp = Number(actor?.system?.experience?.max);
+  const safeMax = Number.isFinite(maxExp) ? Math.max(0, Math.round(maxExp)) : null;
+  const safeValue = Number.isFinite(value) ? Math.round(value) : 0;
+  if (safeMax === null) return Math.max(0, safeValue);
+  return Math.clamp(safeValue, 0, safeMax);
+};
+
 export const CONSUMABLE_PERMANENT_ATTRIBUTE_CONFIG = {
   hpValue: {
     label: "HP actual",
@@ -45,6 +53,30 @@ export const CONSUMABLE_PERMANENT_ATTRIBUTE_CONFIG = {
       const clamped = Math.clamp(Math.round(currentHp), 0, safeMax);
       if (clamped === Math.round(currentHp)) return null;
       return { "system.hp.value": clamped };
+    },
+  },
+  hpTemp: {
+    label: "HP temporal / Escudo",
+    path: "system.hp.temp",
+    clamp: clampNonNegative,
+  },
+  experienceValue: {
+    label: "EXP actual",
+    path: "system.experience.value",
+    clamp: clampExperienceValue,
+  },
+  experienceMax: {
+    label: "EXP máxima",
+    path: "system.experience.max",
+    clamp: clampNonNegative,
+    afterUpdate: (newMax, actor) => {
+      const sourceExp = actor?._source?.system?.experience?.value;
+      const currentExp = Number(sourceExp ?? actor?.system?.experience?.value);
+      if (!Number.isFinite(currentExp)) return null;
+      const safeMax = Number.isFinite(newMax) ? Math.max(0, Math.round(newMax)) : 0;
+      const clamped = Math.clamp(Math.round(currentExp), 0, safeMax);
+      if (clamped === Math.round(currentExp)) return null;
+      return { "system.experience.value": clamped };
     },
   },
   lp: {
@@ -82,10 +114,35 @@ export const CONSUMABLE_PERMANENT_ATTRIBUTE_CONFIG = {
     path: "system.spDefense",
     clamp: clampInteger,
   },
+  stab: {
+    label: "STAB",
+    path: "system.stab",
+    clamp: clampInteger,
+  },
+  basicattack: {
+    label: "Basic Attack",
+    path: "system.basicattack",
+    clamp: clampInteger,
+  },
   accuracyBonus: {
     label: "Precisión global",
     path: "system.accuracyBonus",
     clamp: clampInteger,
+  },
+  critAttackMod: {
+    label: "Mod. crítico (ataques)",
+    path: "system.critAttackMod",
+    clamp: clampInteger,
+  },
+  critDefenseMod: {
+    label: "Mod. crítico (defensa)",
+    path: "system.critDefenseMod",
+    clamp: clampInteger,
+  },
+  belly: {
+    label: "Belly",
+    path: "system.belly",
+    clamp: clampNonNegative,
   },
 };
 

--- a/template.json
+++ b/template.json
@@ -4,7 +4,7 @@
     "templates": {
       "baseCreature": {
         "lvl": 1,
-        "hp": { "max": 10, "value": 10 },
+        "hp": { "max": 10, "value": 10, "temp": 0 },
         "experience": { "max": 100, "value": 0 },
         "attack": 0,
         "spAttack": 0,

--- a/templates/actor-sheet.hbs
+++ b/templates/actor-sheet.hbs
@@ -77,6 +77,10 @@
           <input type="number" name="system.hp.value" value="{{system.hp.value}}" data-dtype="Number"/>
         </div>
         <div class="stat">
+          <label>HP Temporal / Escudo</label>
+          <input type="number" name="system.hp.temp" value="{{system.hp.temp}}" data-dtype="Number"/>
+        </div>
+        <div class="stat">
           <label>HP Máxima</label>
           <input type="number" name="system.hp.max" value="{{system.hp.max}}" data-dtype="Number"/>
         </div>


### PR DESCRIPTION
## Summary
- add a temporary HP/shield attribute to actors and expose it on the character sheet
- expand permanent and active effect attribute lists to cover all character stats and clamp values safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e537d82d3c832bba9b05b868f95b27