### PR TITLE
Allow roll thresholds to include equal results

### DIFF
--- a/module/actor-sheet - copia.js
+++ b/module/actor-sheet - copia.js
@@ -122,7 +122,7 @@ export class MyActorSheet extends ActorSheet {
 
   /**
    * Realiza la tirada 1d100 de HABILIDAD y publica el resultado en el chat.
-   * Éxito si (resultado < umbral). En crítica el umbral es ceil(skill/2).
+   * Éxito si (resultado <= umbral). En crítica el umbral es ceil(skill/2).
    */
   async _rollSkill(skillKey, label = skillKey) {
     const mode = await this._askRollMode();
@@ -132,7 +132,7 @@ export class MyActorSheet extends ActorSheet {
     const threshold = mode === "critical" ? Math.ceil(val / 2) : val;
 
     const roll = await (new Roll("1d100")).evaluate({ async: true });
-    const success = roll.total < threshold;
+    const success = roll.total <= threshold;
 
     const flavor = `
       <div><strong>Tirada de ${label}</strong> (${mode === "critical" ? "Crítica" : "Normal"})</div>
@@ -190,7 +190,7 @@ export class MyActorSheet extends ActorSheet {
    * - Verifica PP > 0
    * - Pide bono
    * - Tira 1d100
-   * - Determina crítico (raw < 10) y acierto (raw+bono < accuracy)
+   * - Determina crítico (raw <= 10) y acierto (raw+bono <= accuracy)
    * - Gasta 1 PP SIEMPRE que se usa (acierte o no)
    */
 async _useMove(item) {
@@ -214,8 +214,8 @@ async _useMove(item) {
   // 4) Tirada d100
   const roll = await (new Roll("1d100")).evaluate({ async: true });
   const raw = roll.total;            // resultado del dado SIN bono
-  const isCrit = raw < 10;           // crítico si resultado crudo < 10
-  const isHit  = raw < finalThreshold; // acierta si crudo < (accuracy + bono)
+  const isCrit = raw <= 10;          // crítico si resultado crudo <= 10
+  const isHit  = raw <= finalThreshold; // acierta si crudo <= (accuracy + bono)
 
   // 5) Gasto de PP (siempre que se usa el movimiento)
   const newPP = Math.max(0, curPP - 1);

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -612,7 +612,7 @@ export class MyActorSheet extends BaseActorSheet {
     const targetActors = this._getTargetActors();
     const baseCritThreshold = 10;
     const attackCritMod = Number(this.actor.system?.critAttackMod ?? 0);
-    const isHit = raw < finalThreshold;
+    const isHit = raw <= finalThreshold;
 
     const baseDamageRaw = Number(this.actor.system?.basicattack ?? 0);
     const baseDamage = Number.isFinite(baseDamageRaw) ? baseDamageRaw : 0;
@@ -621,7 +621,7 @@ export class MyActorSheet extends BaseActorSheet {
     const targetResults = targetActors.map((actor) => {
       const defenderCritMod = Number(actor.system?.critDefenseMod ?? 0);
       const critThreshold = baseCritThreshold + attackCritMod + defenderCritMod;
-      const isCritTarget = isHit && raw < critThreshold;
+      const isCritTarget = isHit && raw <= critThreshold;
       const name = actor.name ?? "Objetivo";
       const uuid = actor.uuid ?? "";
       let finalDamage = 0;
@@ -747,7 +747,7 @@ export class MyActorSheet extends BaseActorSheet {
     const moveCritMod = Number(item.system?.critThresholdMod ?? 0);
     const primaryDefenderCritMod = targetActor ? Number(targetActor.system?.critDefenseMod ?? 0) : 0;
     const primaryCritThreshold = baseCritThreshold + attackCritMod + primaryDefenderCritMod + moveCritMod;
-    const isHit = raw < finalThreshold;
+    const isHit = raw <= finalThreshold;
 
     // Gastar PP
     await item.update({ "system.pp.value": Math.max(0, curPP - 1) });
@@ -784,7 +784,7 @@ export class MyActorSheet extends BaseActorSheet {
     if (canPromptDamage) {
       damageOptions = await this._promptDamageOptions({
         itemName: item.name,
-        isCrit: isHit && raw < primaryCritThreshold,
+        isCrit: isHit && raw <= primaryCritThreshold,
         hasStab,
         effectiveness: autoEffectiveness,
         autoCalculated: Number.isFinite(autoEffectiveness)
@@ -813,7 +813,7 @@ export class MyActorSheet extends BaseActorSheet {
       const isImmune = canDealDamage && Number.isFinite(resolvedEffectiveness) && resolvedEffectiveness === 0;
       const defenderCritMod = Number(actor.system?.critDefenseMod ?? 0);
       const critThreshold = baseCritThreshold + attackCritMod + defenderCritMod + moveCritMod;
-      const isCritTarget = isHit && raw < critThreshold;
+      const isCritTarget = isHit && raw <= critThreshold;
       let finalDamage = 0;
       let canCalculateDamage = false;
       if (isHit && damageOptions && canDealDamage && !isImmune) {
@@ -892,8 +892,8 @@ export class MyActorSheet extends BaseActorSheet {
         for (let i = 0; i < additionalAttacks; i++) {
           const accRoll = await (new Roll("1d100")).evaluate({ async: true });
           const total = accRoll.total;
-          const hit = total < finalThreshold;
-          const critExtra = total < primaryCritThreshold;
+          const hit = total <= finalThreshold;
+          const critExtra = total <= primaryCritThreshold;
           const damage = hit && canCalcMultiDamage && primaryCanCalculate && !primaryImmune && baseDmg > 0 ? baseDmg : 0;
           if (damage > 0) {
             multiDamageTotal += damage;


### PR DESCRIPTION
## Summary
- allow skill rolls to treat results equal to the threshold as successes
- allow accuracy and critical checks to include equal-to-threshold results as hits/criticals

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9673160c4832b84af690494d81fa6